### PR TITLE
Use server.cfg as implemented in tools

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,11 @@
 codecov:
   notify:
-    require_ci_to_pass: no
+    require_ci_to_pass: yes
 
 coverage:
   precision: 2
   round: down
-  range: "50...80"
+  range: "70...100"
 
   status:
     project: yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.7
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         xml: ./coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 # editors
 .idea/
 .vscode/
+
+# OPTiMaDe specific
+server.cfg

--- a/aiida_optimade/config.py
+++ b/aiida_optimade/config.py
@@ -1,46 +1,55 @@
 import json
-from typing import Dict, Set
+from typing import Any
 from pathlib import Path
 
-from optimade.server.config import Config
+from optimade.server.config import Config, NoFallback
 
 
 class ServerConfig(Config):
     """Load config file"""
 
-    ftype = "json"
+    @staticmethod
+    def _DEFAULTS(field: str) -> Any:
+        res = {
+            "version": "v1.0.0",
+            "page_limit": 100,
+            "db_page_limit": 500,
+            "provider": {
+                "prefix": "_aiida_",
+                "name": "AiiDA",
+                "description": "AiiDA: Automated Interactive Infrastructure and Database for Computational Science (http://www.aiida.net)",
+                "homepage": "http://www.aiida.net",
+                "index_base_url": None,
+            },
+            "provider_fields": {},
+        }
+        if field not in res:
+            raise NoFallback(f"No fallback value found for '{field}'")
+        return res[field]
 
-    FILENAME = "config"
-
-    version = "v1.0.0"
-    page_limit = 500
-    db_page_limit = 1000
-    provider = {
-        "prefix": "_aiida_",
-        "name": "AiiDA",
-        "description": "AiiDA: Automated Interactive Infrastructure and Database for Computational Science (http://www.aiida.net)",
-        "homepage": "http://www.aiida.net",
-        "index_base_url": None,
-    }
-    provider_fields: Dict[str, Set] = {}
-
-    def __init__(self, ftype: str = None, filename: str = None):
-        self.FILENAME = self.FILENAME if filename is None else filename
-        super().__init__(ftype)
+    def __init__(self, server_cfg: Path = None):
+        server = (
+            Path(__file__).resolve().parent.parent.joinpath("server.cfg")
+            if server_cfg is None
+            else server_cfg
+        )
+        super().__init__(server)
 
     def load_from_json(self):
         """Load parameters from FILENAME.json"""
 
-        with open(
-            Path(__file__).resolve().parent.joinpath(self.FILENAME + ".json")
-        ) as config_file:
+        with open(self._path) as config_file:
             config = json.load(config_file)
 
-        self.version = config.get("version", self.version)
-        self.page_limit = int(config.get("page_limit", self.page_limit))
-        self.db_page_limit = int(config.get("db_page_limit", self.db_page_limit))
-        self.provider = config.get("provider", self.provider)
-        self.provider_fields = config.get("provider_fields", self.provider_fields)
+        self.version = config.get("version", self._DEFAULTS("version"))
+        self.page_limit = int(config.get("page_limit", self._DEFAULTS("page_limit")))
+        self.db_page_limit = int(
+            config.get("db_page_limit", self._DEFAULTS("db_page_limit"))
+        )
+        self.provider = config.get("provider", self._DEFAULTS("provider"))
+        self.provider_fields = config.get(
+            "provider_fields", self._DEFAULTS("provider_fields")
+        )
 
 
 CONFIG = ServerConfig()

--- a/server_template.cfg
+++ b/server_template.cfg
@@ -1,0 +1,2 @@
+[optimadeconfig]
+CONFIG = ./aiida_optimade/config.json


### PR DESCRIPTION
Blocked until Materials-Consortia/optimade-python-tools#103 has been merged.

Use `server.cfg` to relay path to `config.json`.
This may be used in the future as well to relay path to references JSON data file or similar.