### PR TITLE
Update to pydantic v1

### DIFF
--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -97,9 +97,7 @@ class AiidaCollection:
         del query
         return res
 
-    def count(
-        self, backend: orm.implementation.Backend, **kwargs
-    ):  # pylint: disable=arguments-differ
+    def count(self, backend: orm.implementation.Backend, **kwargs):
         query = self._find(backend, self.collection.entity_type, **kwargs)
         res = query.count()
         del query
@@ -141,7 +139,7 @@ class AiidaCollection:
             self._latest_filter = criteria.get("filters", {})
             self._data_returned = self.count(backend, **criteria)
 
-    def find(  # pylint: disable=arguments-differ
+    def find(
         self,
         backend: orm.implementation.Backend,
         params: Union[EntryListingQueryParams, SingleEntryQueryParams],
@@ -258,7 +256,7 @@ class AiidaCollection:
 
         # response_fields
         # All OPTiMaDe fields
-        fields = {"id", "type"}
+        fields = self.resource_mapper.TOP_LEVEL_NON_ATTRIBUTES_FIELDS.copy()
         fields |= self.get_attribute_fields()
         # All provider-specific fields
         fields |= {self.provider + _ for _ in self.provider_fields}

--- a/aiida_optimade/mappers/entries.py
+++ b/aiida_optimade/mappers/entries.py
@@ -15,6 +15,7 @@ class ResourceMapper(metaclass=abc.ABCMeta):
 
     ENDPOINT: str = ""
     ALIASES: Tuple[Tuple[str, str]] = ()
+    TOP_LEVEL_NON_ATTRIBUTES_FIELDS: set = {"id", "type", "relationships", "links"}
     TRANSLATOR: AiidaEntityTranslator = AiidaEntityTranslator
     ALL_ATTRIBUTES: list = []
     REQUIRED_ATTRIBUTES: list = []
@@ -24,7 +25,7 @@ class ResourceMapper(metaclass=abc.ABCMeta):
         res = (
             tuple(
                 (CONFIG.provider["prefix"] + field, field)
-                for field in CONFIG.provider_fields[cls.ENDPOINT]
+                for field in CONFIG.provider_fields.get(cls.ENDPOINT, {})
             )
             + cls.ALIASES
         )
@@ -46,6 +47,9 @@ class ResourceMapper(metaclass=abc.ABCMeta):
     @abc.abstractclassmethod
     def map_back(self, entity_properties: dict) -> dict:
         """Map properties from AiiDA to OPTiMaDe
+
+        :param entity_properties: Found AiiDA properties through QueryBuilder query
+        :type entity_properties: dict
 
         :return: A resource object in OPTiMaDe format
         :rtype: dict

--- a/aiida_optimade/routers/info.py
+++ b/aiida_optimade/routers/info.py
@@ -59,7 +59,7 @@ def get_info(request: Request):
     "/info/{entry}",
     response_model=Union[EntryInfoResponse, ErrorResponse],
     response_model_skip_defaults=True,
-    tags=["Info", "Structure"],
+    tags=["Info"],
 )
 def get_info_entry(request: Request, entry: str):
     from optimade.models import EntryInfoResource

--- a/aiida_optimade/routers/info.py
+++ b/aiida_optimade/routers/info.py
@@ -24,7 +24,7 @@ ENTRY_INFO_SCHEMAS = {"structures": StructureResource.schema}
 @router.get(
     "/info",
     response_model=Union[InfoResponse, ErrorResponse],
-    response_model_skip_defaults=False,
+    response_model_exclude_unset=False,
     tags=["Info"],
 )
 def get_info(request: Request):
@@ -58,7 +58,7 @@ def get_info(request: Request):
 @router.get(
     "/info/{entry}",
     response_model=Union[EntryInfoResponse, ErrorResponse],
-    response_model_skip_defaults=True,
+    response_model_exclude_unset=True,
     tags=["Info"],
 )
 def get_info_entry(request: Request, entry: str):

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -31,7 +31,7 @@ structures = AiidaCollection(
     "/structures",
     response_model=Union[StructureResponseMany, ErrorResponse],
     response_model_skip_defaults=True,
-    tags=["Structure"],
+    tags=["Structures"],
 )
 def get_structures(
     request: Request,
@@ -51,7 +51,7 @@ def get_structures(
     "/structures/{entry_id}",
     response_model=Union[StructureResponseOne, ErrorResponse],
     response_model_skip_defaults=True,
-    tags=["Structure"],
+    tags=["Structures"],
 )
 def get_single_structure(
     request: Request,

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -30,7 +30,7 @@ structures = AiidaCollection(
 @router.get(
     "/structures",
     response_model=Union[StructureResponseMany, ErrorResponse],
-    response_model_skip_defaults=True,
+    response_model_exclude_unset=True,
     tags=["Structures"],
 )
 def get_structures(
@@ -50,7 +50,7 @@ def get_structures(
 @router.get(
     "/structures/{entry_id}",
     response_model=Union[StructureResponseOne, ErrorResponse],
-    response_model_skip_defaults=True,
+    response_model_exclude_unset=True,
     tags=["Structures"],
 )
 def get_single_structure(

--- a/aiida_optimade/routers/utils.py
+++ b/aiida_optimade/routers/utils.py
@@ -31,20 +31,21 @@ def handle_pagination(
     query["page_offset"] = int(query.get("page_offset", ["0"])[0]) - int(
         query.get("page_limit", [CONFIG.page_limit])[0]
     )
+    urlencoded_prev = None
     if query["page_offset"] > 0:
         urlencoded_prev = urllib.parse.urlencode(query, doseq=True)
-        pagination[
-            "prev"
-        ] = f"{parse_result.scheme}://{parse_result.netloc}{parse_result.path}?{urlencoded_prev}"
     elif query["page_offset"] == 0 or abs(query["page_offset"]) < int(
         query.get("page_limit", [CONFIG.page_limit])[0]
     ):
+        print("here now")
         prev_query = query.copy()
         prev_query.pop("page_offset")
         urlencoded_prev = urllib.parse.urlencode(prev_query, doseq=True)
+    if urlencoded_prev:
         pagination[
             "prev"
-        ] = f"{parse_result.scheme}://{parse_result.netloc}{parse_result.path}?{urlencoded_prev}"
+        ] = f"{parse_result.scheme}://{parse_result.netloc}{parse_result.path}"
+        pagination["prev"] += f"?{urlencoded_prev}"
 
     # "next"
     if more_data_available:
@@ -56,7 +57,9 @@ def handle_pagination(
         urlencoded_next = urllib.parse.urlencode(query, doseq=True)
         pagination[
             "next"
-        ] = f"{parse_result.scheme}://{parse_result.netloc}{parse_result.path}?{urlencoded_next}"
+        ] = f"{parse_result.scheme}://{parse_result.netloc}{parse_result.path}"
+        if urlencoded_next:
+            pagination["next"] += f"?{urlencoded_next}"
     else:
         pagination["next"] = None
 

--- a/aiida_optimade/routers/utils.py
+++ b/aiida_optimade/routers/utils.py
@@ -74,7 +74,7 @@ def handle_response_fields(
     new_results = []
     while results:
         entry = results.pop(0)
-        new_entry = entry.dict(exclude=top_level, skip_defaults=True)
+        new_entry = entry.dict(exclude=top_level, exclude_unset=True)
         for field in attribute_level:
             if field in new_entry["attributes"]:
                 del new_entry["attributes"][field]

--- a/aiida_optimade/tests/test_server.py
+++ b/aiida_optimade/tests/test_server.py
@@ -153,7 +153,7 @@ class TestStructuresEndpointTests(BaseTestCases.EndpointTests):
         next_request = self.json_response["links"]["next"]
 
         id_ = len(cursor)
-        while more_data_available and id_ < CONFIG.page_limit * 5:
+        while more_data_available and id_ < CONFIG.page_limit * 3:
             next_response = self.client.get(next_request).json()
             next_request = next_response["links"]["next"]
             cursor.extend(next_response["data"])

--- a/aiida_optimade/tests/test_server.py
+++ b/aiida_optimade/tests/test_server.py
@@ -33,7 +33,7 @@ from aiida_optimade.main import app
 from aiida_optimade.routers import structures, info
 
 # need to explicitly set base_url, as the default "http://testserver"
-# does not validate as pydantic UrlStr model
+# does not validate as pydantic AnyUrl model
 app.include_router(structures.router)
 app.include_router(info.router)
 CLIENT = TestClient(app, base_url="http://localhost:5000/optimade")

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -74,7 +74,7 @@ def general_exception(
                 ),
                 errors=errors,
             ),
-            skip_defaults=True,
+            exclude_unset=True,
         ),
     )
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ filterwarnings =
     ignore:.*PY_SSIZE_T_CLEAN will be required for '#' formats.*:DeprecationWarning
     ignore:.*"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead.*:DeprecationWarning
     ignore:.*Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning
+    ignore:.*Check the index_links.json file exists.*:UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 filterwarnings =
     ignore:.*PY_SSIZE_T_CLEAN will be required for '#' formats.*:DeprecationWarning
     ignore:.*"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead.*:DeprecationWarning
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning
+    ignore:.*Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning

--- a/setup.json
+++ b/setup.json
@@ -1,6 +1,6 @@
 {
   "name": "aiida-optimade",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "url": "https://github.com/aiidateam/aiida-optimade",
   "license": "MIT License",
   "author": "The AiiDA team",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "fastapi~=0.44",
         "lark-parser~=0.7.8",
         "optimade~=0.2",
-        "pydantic<1.0.0",
+        "pydantic~=1.0, <2.0.0",
         "uvicorn",
     ],
     extras_require={"dev": dev_deps, "testing": testing_deps},


### PR DESCRIPTION
Fixes #27 

This will update this package to 0.3.1.

Fixes relevant for `pydantic` v1.

Minor fixes include:

- Adapting `pytest.ini` to not show irrelevant warnings.
- Implementing the same as was done for Materials-Consortia/optimade-python-tools#121, i.e., fix OpenAPI headlines by fixing endpoint tags in the routers.
- Update the mappers. Specifically introduce TOP_LEVEL_NON_ATTRIBUTES_FIELDS and remove irrelevant code from the structure mapper.
- Remove a few `pylint` disable comments.