### PR TITLE
Update session handling per request as per new AiiDA PR 3708

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v2.4.0
   hooks:
   - id: trailing-whitespace
     exclude: README.md
@@ -8,7 +8,7 @@ repos:
   - id: check-json
 
 - repo: https://github.com/ambv/black
-  rev: stable
+  rev: 19.10b0
   hooks:
   - id: black
     name: Blacken

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -1,4 +1,3 @@
-# pylint: disable=line-too-long
 import os
 
 from lark.exceptions import VisitError
@@ -7,23 +6,22 @@ from pydantic import ValidationError
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.requests import Request
 
 from aiida import load_profile
 
 from optimade import __api_version__
 import optimade.server.exception_handlers as exc_handlers
 
-from aiida_optimade.common.exceptions import AiidaError
-
 
 APP = FastAPI(
     title="OPTiMaDe API for AiiDA",
     description=(
-        "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](http://www.optimade.org/) "
-        "aims to make materials databases inter-operational by developing a common REST API.\n\n"
-        "[Automated Interactive Infrastructure and Database for Computational Science (AiiDA)](http://www.aiida.net) "
-        "aims to help researchers with managing complex workflows and making them fully reproducible."
+        "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium]"
+        "(http://www.optimade.org/) aims to make materials databases inter-operational "
+        "by developing a common REST API.\n\n[Automated Interactive Infrastructure "
+        "and Database for Computational Science (AiiDA)](http://www.aiida.net) aims to "
+        "help researchers with managing complex workflows and making them fully "
+        "reproducible."
     ),
     version=__api_version__,
     docs_url="/optimade/extensions/docs",
@@ -33,25 +31,6 @@ APP = FastAPI(
 
 PROFILE_NAME = os.getenv("AIIDA_PROFILE")
 load_profile(PROFILE_NAME)
-
-
-@APP.middleware("http")
-async def backend_middleware(request: Request, call_next):
-    """Use custom AiiDA backend for all requests"""
-    from aiida.manage.manager import get_manager
-    from aiida.backends.sqlalchemy import reset_session
-
-    response = None
-
-    # Reset global AiiDA session and engine
-    if get_manager().backend_loaded:
-        reset_session(get_manager().get_profile())
-
-    response = await call_next(request)
-    if response:
-        return response
-    raise AiidaError("Failed to properly handle AiiDA backend middleware")
-
 
 APP.add_exception_handler(StarletteHTTPException, exc_handlers.http_exception_handler)
 APP.add_exception_handler(

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -17,7 +17,7 @@ from aiida_optimade.query_params import EntryListingQueryParams, SingleEntryQuer
 from aiida_optimade.entry_collections import AiidaCollection
 from aiida_optimade.mappers import StructureMapper
 
-from .utils import get_entries, get_single_entry
+from .utils import get_entries, get_single_entry, close_session
 
 
 ROUTER = APIRouter()
@@ -31,6 +31,7 @@ STRUCTURES = AiidaCollection(StructureData, StructureResource, StructureMapper)
     response_model_exclude_unset=True,
     tags=["Structures"],
 )
+@close_session
 def get_structures(request: Request, params: EntryListingQueryParams = Depends()):
     return get_entries(
         collection=STRUCTURES,
@@ -46,6 +47,7 @@ def get_structures(request: Request, params: EntryListingQueryParams = Depends()
     response_model_exclude_unset=True,
     tags=["Structures"],
 )
+@close_session
 def get_single_structure(
     request: Request, entry_id: int, params: SingleEntryQueryParams = Depends()
 ):

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -1,7 +1,5 @@
 from typing import Tuple
 
-from starlette.requests import Request
-
 
 def retrieve_queryable_properties(
     schema: dict, queryable_properties: list

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        "aiida-core~=1.0",
+        "aiida-core @ git+https://github.com/aiidateam/aiida-core@develop"
+        "#egg=aiida-core",
         "fastapi~=0.47",
         "lark-parser~=0.8.1",
         "optimade[mongo]~=0.3.3",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ MODULE_DIR = Path(__file__).resolve().parent
 with open(MODULE_DIR.joinpath("setup.json")) as handle:
     SETUP_JSON = json.load(handle)
 
-TESTING = ["pytest~=3.6", "pytest-cov", "codecov"]
+TESTING = ["pytest>=3.6", "pytest-cov", "codecov"]
 DEV = ["pylint", "black", "pre-commit", "invoke"] + TESTING
 
 setup(
@@ -18,9 +18,9 @@ setup(
     install_requires=[
         "aiida-core~=1.0",
         "fastapi~=0.47",
-        "lark-parser~=0.7.8",
+        "lark-parser~=0.8.1",
         "optimade[mongo]~=0.3.3",
-        "pydantic~=1.3",
+        "pydantic~=1.4",
         "uvicorn",
     ],
     extras_require={"dev": DEV, "testing": TESTING},


### PR DESCRIPTION
Updating this code according to the PR aiidateam/aiida-core#3708.

~~The `backend` parameter has been removed throughout the code, `aiida_session.py` has been removed, since this "hack" is no longer used. Instead the HTTP middleware awaits the response and _always_ resets the AiiDA backend environment afterwards, i.e., calls the backend-specific `reset_session()` function.~~
The `backend` parameter has already been removed in #23.
The HTTP middleware has now been completely removed, in favor of a `close_session` decorator that should be used for each router endpoint that uses AiiDA in creating the response.

~~Note: For the tests to pass for the django backend, a fix is is needed in the `aiida-core` PR for importing the correct `reset_session()` function.~~