### PR TITLE
Redirect special OpenAPI endpoints for custom base URLs

### DIFF
--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -16,15 +16,16 @@ import optimade.server.exception_handlers as exc_handlers
 from optimade.server.middleware import EnsureQueryParamIntegrity
 from optimade.server.routers.utils import BASE_URL_PREFIXES
 
+from aiida_optimade.middleware import RedirectOpenApiDocs
 from aiida_optimade.routers import (
     info,
     structures,
 )
+from aiida_optimade.utils import get_custom_base_url_path
 
 
 if CONFIG.debug:  # pragma: no cover
     print("DEBUG MODE")
-
 
 # Load AiiDA profile
 PROFILE_NAME = os.getenv("AIIDA_PROFILE")
@@ -32,6 +33,7 @@ load_profile(PROFILE_NAME)
 if CONFIG.debug:  # pragma: no cover
     print(f"AiiDA Profile: {PROFILE_NAME}")
 
+DOCS_ENDPOINT_PREFIX = f"{get_custom_base_url_path()}{BASE_URL_PREFIXES['major']}"
 APP = FastAPI(
     title="OPTIMADE API for AiiDA",
     description=(
@@ -43,15 +45,16 @@ APP = FastAPI(
         "reproducible."
     ),
     version=__api_version__,
-    docs_url=f"{BASE_URL_PREFIXES['major']}/extensions/docs",
-    redoc_url=f"{BASE_URL_PREFIXES['major']}/extensions/redoc",
-    openapi_url=f"{BASE_URL_PREFIXES['major']}/extensions/openapi.json",
+    docs_url=f"{DOCS_ENDPOINT_PREFIX}/extensions/docs",
+    redoc_url=f"{DOCS_ENDPOINT_PREFIX}/extensions/redoc",
+    openapi_url=f"{DOCS_ENDPOINT_PREFIX}/extensions/openapi.json",
 )
 
 
 # Add various middleware
 APP.add_middleware(CORSMiddleware, allow_origins=["*"])
 APP.add_middleware(EnsureQueryParamIntegrity)
+APP.add_middleware(RedirectOpenApiDocs)
 
 
 # Add various exception handlers

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -21,7 +21,7 @@ from aiida_optimade.routers import (
     info,
     structures,
 )
-from aiida_optimade.utils import get_custom_base_url_path
+from aiida_optimade.utils import get_custom_base_url_path, OPEN_API_ENDPOINTS
 
 
 if CONFIG.debug:  # pragma: no cover
@@ -45,9 +45,9 @@ APP = FastAPI(
         "reproducible."
     ),
     version=__api_version__,
-    docs_url=f"{DOCS_ENDPOINT_PREFIX}/extensions/docs",
-    redoc_url=f"{DOCS_ENDPOINT_PREFIX}/extensions/redoc",
-    openapi_url=f"{DOCS_ENDPOINT_PREFIX}/extensions/openapi.json",
+    docs_url=f"{DOCS_ENDPOINT_PREFIX}{OPEN_API_ENDPOINTS['docs']}",
+    redoc_url=f"{DOCS_ENDPOINT_PREFIX}{OPEN_API_ENDPOINTS['redoc']}",
+    openapi_url=f"{DOCS_ENDPOINT_PREFIX}{OPEN_API_ENDPOINTS['openapi']}",
 )
 
 

--- a/aiida_optimade/middleware.py
+++ b/aiida_optimade/middleware.py
@@ -1,0 +1,40 @@
+import urllib.parse
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+
+from optimade.server.routers.utils import BASE_URL_PREFIXES
+
+
+class RedirectOpenApiDocs(BaseHTTPMiddleware):
+    """Redirect URLs from non-major version prefix URLs to major-version prefix URLs
+
+    This is relevant for the OpenAPI JSON, Docs, and ReDocs URLs.
+    """
+
+    SPECIAL_ENDPOINTS = {
+        "docs_url": "/extensions/docs",
+        "redoc_url": "/extensions/redoc",
+        "openapi_url": "/extensions/openapi.json",
+    }
+
+    async def dispatch(self, request: Request, call_next):
+        parsed_url = urllib.parse.urlsplit(str(request.url))
+        for endpoint in self.SPECIAL_ENDPOINTS.values():
+            # Important to start with the longest (or full) URL prefix first.
+            for version_prefix in [
+                BASE_URL_PREFIXES["patch"],
+                BASE_URL_PREFIXES["minor"],
+            ]:
+                if parsed_url.path.endswith(f"{version_prefix}{endpoint}"):
+                    new_path = parsed_url.path.replace(
+                        f"{version_prefix}", f"{BASE_URL_PREFIXES['major']}"
+                    )
+                    redirect_url = (
+                        f"{parsed_url.scheme}://{parsed_url.netloc}{new_path}"
+                        f"?{parsed_url.query}"
+                    )
+                    return RedirectResponse(redirect_url)
+        response = await call_next(request)
+        return response

--- a/aiida_optimade/middleware.py
+++ b/aiida_optimade/middleware.py
@@ -6,6 +6,8 @@ from starlette.responses import RedirectResponse
 
 from optimade.server.routers.utils import BASE_URL_PREFIXES
 
+from aiida_optimade.utils import OPEN_API_ENDPOINTS
+
 
 class RedirectOpenApiDocs(BaseHTTPMiddleware):
     """Redirect URLs from non-major version prefix URLs to major-version prefix URLs
@@ -13,15 +15,9 @@ class RedirectOpenApiDocs(BaseHTTPMiddleware):
     This is relevant for the OpenAPI JSON, Docs, and ReDocs URLs.
     """
 
-    SPECIAL_ENDPOINTS = {
-        "docs_url": "/extensions/docs",
-        "redoc_url": "/extensions/redoc",
-        "openapi_url": "/extensions/openapi.json",
-    }
-
     async def dispatch(self, request: Request, call_next):
         parsed_url = urllib.parse.urlsplit(str(request.url))
-        for endpoint in self.SPECIAL_ENDPOINTS.values():
+        for endpoint in OPEN_API_ENDPOINTS.values():
             # Important to start with the longest (or full) URL prefix first.
             for version_prefix in [
                 BASE_URL_PREFIXES["patch"],

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -4,6 +4,13 @@ import urllib.parse
 from optimade.server.config import CONFIG
 
 
+OPEN_API_ENDPOINTS = {
+    "docs": "/extensions/docs",
+    "redoc": "/extensions/redoc",
+    "openapi": "/extensions/openapi.json",
+}
+
+
 def retrieve_queryable_properties(
     schema: dict, queryable_properties: list
 ) -> Tuple[dict, dict]:

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -1,4 +1,7 @@
 from typing import Tuple
+import urllib.parse
+
+from optimade.server.config import CONFIG
 
 
 def retrieve_queryable_properties(
@@ -30,3 +33,16 @@ def retrieve_queryable_properties(
                         properties[name][extra_key] = value[extra_key]
 
     return properties, all_properties
+
+
+def get_custom_base_url_path():
+    """Return path part of custom base URL"""
+    if CONFIG.base_url is not None:
+        res = urllib.parse.urlparse(CONFIG.base_url).path
+    else:
+        res = urllib.parse.urlparse(CONFIG.base_url).path.decode()
+
+    if res.endswith("/"):
+        res = res[:-1]
+
+    return res

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ from optimade.validator import ImplementationValidator
 
 # Use specific AiiDA profile
 if os.getenv("AIIDA_PROFILE", None) is None:
-    os.environ["AIIDA_PROFILE"] = "optimade_v1_aiida_sqla"
+    os.environ["AIIDA_PROFILE"] = "optimade_sqla"
 
 from optimade.models import (
     ResponseMeta,


### PR DESCRIPTION
Fixes #71 

Redirect all non-major version prefix URLs to major-version prefix URLs
for the special OpenAPI docs endpoints:
- docs_url: /extensions/docs
- redoc_url: /extensions/redoc
- openapi_url: /extensions/openapi.json

Note: There are not tests added for this, since it would require a restructuring of the testing, since it would best be tested with an actual running server, i.e., not using the `TestClient`.
In any case, another PR is underway to update the tests significantly. Tests for this should/could be added at that point.