### PR TITLE
Use threshold properly in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,8 @@
 codecov:
   notify:
-    require_ci_to_pass: yes
+    after_n_builds: 2
+    wait_for_ci: yes
+  require_ci_to_pass: yes
 
 coverage:
   precision: 2
@@ -8,7 +10,10 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
-    patch: yes
-    changes: no
-    threshold: 1
+    project:
+      default:
+        threshold: 0.5%
+    patch:
+      default:
+        threshold: 0.5%
+    changes: off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-
     steps:
     - uses: actions/checkout@v2
 
@@ -119,9 +116,6 @@ jobs:
 
   docker-image:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
 
     services:
       postgres:


### PR DESCRIPTION
Fixes #77 

Remove unused `strategy->fail-fast` in GH Actions jobs without a matrix.