### PR TITLE
Add sortable key and provider-specific properties to /info/structures

### DIFF
--- a/aiida_optimade/mappers/structures.py
+++ b/aiida_optimade/mappers/structures.py
@@ -1,5 +1,4 @@
-from optimade.models import StructureResourceAttributes
-
+from aiida_optimade.models import StructureResourceAttributes
 from aiida_optimade.translators import StructureDataTranslator
 
 from .entries import ResourceMapper

--- a/aiida_optimade/models/__init__.py
+++ b/aiida_optimade/models/__init__.py
@@ -1,0 +1,4 @@
+from .structures import StructureResource, StructureResourceAttributes
+
+
+__all__ = ("StructureResource", "StructureResourceAttributes")

--- a/aiida_optimade/models/structures.py
+++ b/aiida_optimade/models/structures.py
@@ -1,0 +1,34 @@
+# pylint: disable=missing-class-docstring,too-few-public-methods
+from datetime import datetime
+
+from pydantic import Field
+
+from optimade.models import (
+    StructureResource as OptimadeStructureResource,
+    StructureResourceAttributes as OptimadeStructureResourceAttributes,
+)
+from optimade.server.config import CONFIG
+
+
+def prefix_provider(string: str) -> str:
+    """Prefix string with `_{provider}_`"""
+    if string in CONFIG.provider_fields.get("structures", []):
+        return f"_{CONFIG.provider.prefix}_{string}"
+    return string
+
+
+class StructureResourceAttributes(OptimadeStructureResourceAttributes):
+    """Extended StructureResourceAttributes for AiiDA-specific fields"""
+
+    ctime: datetime = Field(
+        ..., description="Creation time of the Node in the AiiDA database.",
+    )
+
+    class Config:
+        alias_generator = prefix_provider
+
+
+class StructureResource(OptimadeStructureResource):
+    """Extended StructureResourceAttributes for AiiDA-specific fields"""
+
+    attributes: StructureResourceAttributes

--- a/aiida_optimade/routers/info.py
+++ b/aiida_optimade/routers/info.py
@@ -9,10 +9,10 @@ from optimade.models import (
     ErrorResponse,
     InfoResponse,
     EntryInfoResponse,
-    StructureResource,
 )
 from optimade.server.routers.utils import meta_values
 
+from aiida_optimade.models import StructureResource
 from aiida_optimade.utils import retrieve_queryable_properties
 
 

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -7,7 +7,6 @@ from aiida.orm import StructureData
 
 from optimade.models import (
     ErrorResponse,
-    StructureResource,
     StructureResponseMany,
     StructureResponseOne,
 )
@@ -15,6 +14,7 @@ from optimade.server.query_params import EntryListingQueryParams, SingleEntryQue
 
 from aiida_optimade.entry_collections import AiidaCollection
 from aiida_optimade.mappers import StructureMapper
+from aiida_optimade.models import StructureResource
 
 from .utils import get_entries, get_single_entry, close_session
 

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -38,6 +38,12 @@ def retrieve_queryable_properties(
                 for extra_key in ["unit"]:
                     if extra_key in value:
                         properties[name][extra_key] = value[extra_key]
+                # AiiDA's QueryBuilder can sort everything that isn't a list (array)
+                # or dict (object)
+                properties[name]["sortable"] = value.get("type", "") not in [
+                    "array",
+                    "object",
+                ]
 
     return properties, all_properties
 

--- a/tests/server/routers/test_info.py
+++ b/tests/server/routers/test_info.py
@@ -38,6 +38,49 @@ class TestInfoStructuresEndpoint(EndpointTests):
         data = EntryInfoResource.schema()["required"]
         self.check_keys(data, self.json_response["data"])
 
+    def test_info_structures_sortable(self):
+        """Check the sortable key is present for all properties"""
+        for info_keys in (
+            self.json_response.get("data", {}).get("properties", {}).values()
+        ):
+            assert "sortable" in info_keys
+
+    def test_sortable_values(self):
+        """Make sure certain properties are and are not sortable"""
+        sortable = ["id", "nelements", "nsites"]
+        non_sortable = ["species", "lattice_vectors", "dimension_types"]
+
+        for field in sortable:
+            sortable_info_value = (
+                self.json_response.get("data", {})
+                .get("properties", {})
+                .get(field, {})
+                .get("sortable", None)
+            )
+            assert sortable_info_value is not None
+            assert sortable_info_value is True
+
+        for field in non_sortable:
+            sortable_info_value = (
+                self.json_response.get("data", {})
+                .get("properties", {})
+                .get(field, {})
+                .get("sortable", None)
+            )
+            assert sortable_info_value is not None
+            assert sortable_info_value is False
+
+    def test_info_structures_unit(self):
+        """Check the unit key is present for certain properties"""
+        unit_fields = ["lattice_vectors", "cartesian_site_positions"]
+        for field, info_keys in (
+            self.json_response.get("data", {}).get("properties", {}).items()
+        ):
+            if field in unit_fields:
+                assert "unit" in info_keys
+            else:
+                assert "unit" not in info_keys
+
 
 @pytest.mark.skip("References has not yet been implemented")
 class TestInfoReferencesEndpoint(EndpointTests):

--- a/tests/server/routers/test_info.py
+++ b/tests/server/routers/test_info.py
@@ -77,9 +77,32 @@ class TestInfoStructuresEndpoint(EndpointTests):
             self.json_response.get("data", {}).get("properties", {}).items()
         ):
             if field in unit_fields:
-                assert "unit" in info_keys
+                assert "unit" in info_keys, f"Field: {field}"
             else:
-                assert "unit" not in info_keys
+                assert "unit" not in info_keys, f"Field: {field}"
+
+    def test_provider_fields(self):
+        """Check the presence of AiiDA-specific fields"""
+        from optimade.server.config import CONFIG
+
+        provider_fields = CONFIG.provider_fields.get("structures", [])
+
+        if not provider_fields:
+            import warnings
+
+            warnings.warn("No provider-specific fields found for 'structures'!")
+            return
+
+        for field in provider_fields:
+            updated_field_name = f"_{CONFIG.provider.prefix}_{field}"
+            assert updated_field_name in self.json_response.get("data", {}).get(
+                "properties", {}
+            )
+
+            for static_key in ["description", "sortable"]:
+                assert static_key in self.json_response.get("data", {}).get(
+                    "properties", {}
+                ).get(updated_field_name, {})
 
 
 @pytest.mark.skip("References has not yet been implemented")


### PR DESCRIPTION
Fixes #83 

Provider-specific properties are "hard-coded" into a pydantic model (sub-classing the respective `optimade-python-tools` models), in order to use the `pydantic.Field` class to describe the field and utilize it for the introspective `/info/structures` endpoint.

For the sortable key, an AiiDA-specific addition has been put in place for the utility function that retrieves all properties for the `/info/<entry-list>` endpoints.
If the Open API JSON schema `type` is either `array` or `object`, i.e., `list`/`set`/`tuple` or `dict`, respectively (i.e., a container of sorts), it's `sortable` key will be set to `False` and `True` otherwise.