### PR TITLE
Use /links router directly from optimade-python-tools

### DIFF
--- a/aiida_optimade/data/links.json
+++ b/aiida_optimade/data/links.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "index",
+    "type": "links",
+    "name": "Index Meta-Database",
+    "description": "Index for AiiDA databases exposing OPTIMADE APIs",
+    "base_url": null,
+    "homepage": "http://www.aiida.net/",
+    "link_type": "root"
+  }
+]

--- a/aiida_optimade/routers/links.py
+++ b/aiida_optimade/routers/links.py
@@ -1,0 +1,32 @@
+"""Reusing the optimade-python-tools /links endpoint"""
+# pylint: disable=missing-function-docstring
+from typing import Union
+
+from fastapi import APIRouter, Depends, Request
+
+from optimade.models import ErrorResponse, LinksResponse, LinksResource
+from optimade.server.config import CONFIG
+from optimade.server.entry_collections import MongoCollection, client
+from optimade.server.mappers import LinksMapper
+from optimade.server.query_params import EntryListingQueryParams
+from optimade.server.routers.utils import get_entries
+
+ROUTER = APIRouter(redirect_slashes=True)
+
+LINKS = MongoCollection(
+    collection=client[CONFIG.mongo_database][CONFIG.links_collection],
+    resource_cls=LinksResource,
+    resource_mapper=LinksMapper,
+)
+
+
+@ROUTER.get(
+    "/links",
+    response_model=Union[LinksResponse, ErrorResponse],
+    response_model_exclude_unset=True,
+    tags=["Links"],
+)
+def get_links(request: Request, params: EntryListingQueryParams = Depends()):
+    return get_entries(
+        collection=LINKS, response=LinksResponse, request=request, params=params
+    )

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ MODULE_DIR = Path(__file__).resolve().parent
 with open(MODULE_DIR.joinpath("setup.json")) as handle:
     SETUP_JSON = json.load(handle)
 
-TESTING = ["pytest~=5.4", "pytest-cov", "codecov"]
-DEV = ["pylint", "black", "pre-commit", "invoke"] + TESTING
+TESTING = ["pytest~=5.4", "pytest-cov~=2.10", "codecov~=2.1"]
+DEV = ["pylint~=2.5", "black~=19.10b0", "pre-commit~=2.5", "invoke~=1.4"] + TESTING
 
 setup(
     long_description=open(MODULE_DIR.joinpath("README.md")).read(),
@@ -17,9 +17,9 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "aiida-core~=1.2.1",
-        "fastapi~=0.54.2",
-        "lark-parser~=0.8.5",
-        "optimade[mongo]~=0.8.1",
+        "fastapi~=0.58.0",
+        "lark-parser~=0.8.9",
+        "optimade[mongo]~=0.9.1",
         "pydantic~=1.5",
         "uvicorn~=0.11.5",
     ],

--- a/tests/server/query_params/test_sort.py
+++ b/tests/server/query_params/test_sort.py
@@ -1,11 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from aiida import orm
 
 
 def fmt_datetime(object_: datetime) -> str:
     """Parse datetime into pydantic's JSON encoded datetime string"""
-    as_string = object_.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
-    return f"{as_string[:-2]}:{as_string[-2:]}"
+    return object_.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def test_int_asc(get_good_response):


### PR DESCRIPTION
Fixes #81 

This also means reusing the `MongoCollection`.
The data is stored in `aiida_optimade/data/links.json`.
Mongomock is used as the "backend" for this endpoint.

Note: This update will not work until optimade-python-tools has released a new version that includes the updated `LinksResource` schema.