### PR TITLE
Move dependencies to dedicated requirements files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
     - uses: actions/checkout@v2
@@ -28,8 +29,8 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   pre-commit:
-
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
     - uses: actions/checkout@v2
@@ -49,14 +50,14 @@ jobs:
       run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
 
   pytest:
-
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
-        # TODO: 3.7 on GH Actions currently doesn't work with PyYAML (dependency of aiida-core)
-        python-version: [3.6, 3.8]
+        # TODO: 3.7.8 on GH Actions currently doesn't work with PyYAML (dependency of aiida-core)
+        python-version: [3.6, 3.7.7, 3.8]
         backend: ['django', 'sqlalchemy']
 
     services:
@@ -113,6 +114,7 @@ jobs:
 
   docker-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     services:
       postgres:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install aiida-core==${AIIDA_VERSION}
 RUN reentry scan
 
 # Copy repo contents
-COPY setup.py setup.json README.md ./
+COPY setup.py setup.json README.md requirements*.txt ./
 COPY aiida_optimade ./aiida_optimade
 RUN pip install -e .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+aiida-core~=1.3.0
+fastapi~=0.59.0
+lark-parser~=0.9.0
+optimade[mongo]~=0.10.0
+pydantic~=1.6
+uvicorn~=0.11.5
+click~=7.1
+click-completion~=0.5.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+pylint~=2.5
+black~=19.10b0
+pre-commit~=2.6
+invoke~=1.4

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,0 +1,4 @@
+pytest~=5.4
+pytest-cov~=2.10
+codecov~=2.1
+pgtest~=1.3,>=1.3.1

--- a/setup.py
+++ b/setup.py
@@ -7,29 +7,26 @@ MODULE_DIR = Path(__file__).resolve().parent
 with open(MODULE_DIR.joinpath("setup.json")) as handle:
     SETUP_JSON = json.load(handle)
 
-TESTING = ["pytest~=5.4", "pytest-cov~=2.10", "codecov~=2.1", "pgtest~=1.3,>=1.3.1"]
-DEV = ["pylint~=2.5", "black~=19.10b0", "pre-commit~=2.6", "invoke~=1.4"] + TESTING
+with open(MODULE_DIR.joinpath("requirements.txt")) as handle:
+    REQUIREMENTS = [f"{_.strip()}" for _ in handle.readlines()]
+
+with open(MODULE_DIR.joinpath("requirements_testing.txt")) as handle:
+    TESTING = [f"{_.strip()}" for _ in handle.readlines()]
+
+with open(MODULE_DIR.joinpath("requirements_dev.txt")) as handle:
+    DEV = [f"{_.strip()}" for _ in handle.readlines()] + TESTING
 
 setup(
     long_description=open(MODULE_DIR.joinpath("README.md")).read(),
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["tests", "profiles"]),
     python_requires=">=3.6",
-    install_requires=[
-        "aiida-core~=1.3.0",
-        "fastapi~=0.59.0",
-        "lark-parser~=0.9.0",
-        "optimade[mongo]~=0.10.0",
-        "pydantic~=1.6",
-        "uvicorn~=0.11.5",
-        "click~=7.1",
-        "click-completion~=0.5.2",
-    ],
+    install_requires=REQUIREMENTS,
     extras_require={"dev": DEV, "testing": TESTING},
     entry_points={
         "console_scripts": [
             "aiida-optimade = aiida_optimade.cli.cmd_aiida_optimade:cli",
         ],
     },
-    **SETUP_JSON
+    **SETUP_JSON,
 )


### PR DESCRIPTION
This is done for clarity and to have `dependabot` work better.