### PR TITLE
Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+  # Should be bigger than or equal to the total number of dependencies (currently 16)
+  open-pull-requests-limit: 20
   target-branch: develop
-  reviewers:
-  - CasperWA
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: 3.7.8 on GH Actions currently doesn't work with PyYAML (dependency of aiida-core)
-        python-version: [3.6, 3.7.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         backend: ['django', 'sqlalchemy']
 
     services:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 aiida-core~=1.3.0
-fastapi~=0.59.0
+fastapi~=0.61.0
 lark-parser~=0.9.0
 optimade[mongo]~=0.10.0
 pydantic~=1.6
-uvicorn~=0.11.5
+uvicorn~=0.11.8
 click~=7.1
 click-completion~=0.5.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 pylint~=2.5
 black~=19.10b0
-pre-commit~=2.6
+pre-commit~=2.7
 invoke~=1.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pylint~=2.5
+pylint~=2.6
 black~=19.10b0
 pre-commit~=2.7
 invoke~=1.4

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,4 +1,4 @@
-pytest~=5.4
+pytest~=6.0
 pytest-cov~=2.10
 codecov~=2.1
-pgtest~=1.3,>=1.3.1
+pgtest~=1.3


### PR DESCRIPTION
All dependencies that passed CI tests (this excludes `optimade`).
Adds dependency checks for GH Actions dependencies.
Revert fixture on Python 3.7.7 in CI tests to simply 3.7.