### PR TITLE
Rely on `optimade` for certain dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 aiida-core~=1.3.0
-fastapi~=0.61.0
-lark-parser~=0.9.0
-optimade[mongo]~=0.11.0
-pydantic~=1.6
-uvicorn~=0.11.8
 click~=7.1
 click-completion~=0.5.2
+optimade[mongo]~=0.11.0
+uvicorn~=0.11.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pylint~=2.6
 black~=19.10b0
-pre-commit~=2.7
 invoke~=1.4
+pre-commit~=2.7
+pylint~=2.6

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,4 +1,4 @@
-pytest~=6.0
-pytest-cov~=2.10
 codecov~=2.1
 pgtest~=1.3
+pytest~=6.0
+pytest-cov~=2.10


### PR DESCRIPTION
This includes:
- fastapi
- lark-parser
- pydantic

Also, sort dependencies in requirements*.txt alphabetically.