### PR TITLE
Add -f/--force option to aiida-optimade init

### DIFF
--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -70,7 +70,7 @@ class AiidaCollection:
         for key in kwargs:
             if key not in {"filters", "order_by", "limit", "project", "offset"}:
                 raise ValueError(
-                    f"You supplied key {key}. _find() only takes the keys: "
+                    f"You supplied key {key!r}. _find() only takes the keys: "
                     '"filters", "order_by", "limit", "project", "offset"'
                 )
 


### PR DESCRIPTION
Closes #128.

This will remove all OPTIMADE-specific extras (currently only `optimade`) for all Nodes that has the key, before (re-)initializing/calculating the OPTIMADE fields for the AiiDA database.

---

Missing:
- [x] Test(s).