### PR TITLE
Don't do codecov pre-commit hook in CI

### DIFF
--- a/.ci/.pre-commit-config.yaml
+++ b/.ci/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: trailing-whitespace
+    exclude: README.md
+  - id: check-yaml
+  - id: check-json
+
+- repo: https://github.com/ambv/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+    name: Blacken
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: '3.8.3'
+  hooks:
+  - id: flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         pip install pre-commit
 
     - name: Test with pre-commit
-      run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+      run: pre-commit run --all-files -c .ci/.pre-commit-config.yaml || ( git status --short ; git diff ; exit 1 )
 
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Create CI pre-commit config without codecov hook that can be called in the CI workflow.