### PR TITLE
Default configuration to config.json in repo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,8 @@ include Dockerfile
 include .dockerignore
 include LICENSE
 include README.md
-include run.sh
+include setup.cfg
 include setup.json
+include requirements*.txt
+include aiida_optimade/*.json
+include aiida_optimade/data/*.json

--- a/aiida_optimade/cli/cmd_aiida_optimade.py
+++ b/aiida_optimade/cli/cmd_aiida_optimade.py
@@ -22,7 +22,7 @@ from aiida_optimade.cli.options import AIIDA_PROFILES
     f"{', '.join([repr(name) for name in AIIDA_PROFILES])}.",
 )
 @click.pass_context
-def cli(ctx, profile: Profile):
+def cli(ctx, profile: Profile):  # pragma: no cover
     """AiiDA-OPTIMADE command line interface (CLI)."""
 
     if ctx.obj is None:

--- a/aiida_optimade/cli/cmd_aiida_optimade.py
+++ b/aiida_optimade/cli/cmd_aiida_optimade.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import click
 
 from aiida.cmdline.params.options import PROFILE as VERDI_PROFILE
@@ -26,3 +29,12 @@ def cli(ctx, profile: Profile):
         ctx.obj = {}
 
     ctx.obj["profile"] = profile
+
+    # Set config
+    if (
+        not os.getenv("OPTIMADE_CONFIG_FILE")
+        or not Path(os.getenv("OPTIMADE_CONFIG_FILE")).exists()
+    ):
+        os.environ["OPTIMADE_CONFIG_FILE"] = str(
+            Path(__file__).parent.parent.joinpath("config.json").resolve()
+        )

--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -39,7 +39,7 @@ class AiidaCollection:
 
         self.transformer = AiidaTransformer()
         self.provider = CONFIG.provider.prefix
-        self.provider_fields = CONFIG.provider_fields[resource_mapper.ENDPOINT]
+        self.provider_fields = CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
         self.parser = LarkParser()
 
         # "Cache"

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import warnings
 import bson.json_util
 
 from lark.exceptions import VisitError
@@ -14,7 +15,12 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from aiida import load_profile
 
 from optimade import __api_version__
-from optimade.server.config import CONFIG
+
+with warnings.catch_warnings(record=True) as w:
+    from optimade.server.config import CONFIG
+
+    config_warnings = w
+
 import optimade.server.exception_handlers as exc_handlers
 from optimade.server.middleware import (
     EnsureQueryParamIntegrity,
@@ -34,6 +40,18 @@ from aiida_optimade.routers import (
 )
 from aiida_optimade.utils import get_custom_base_url_path, OPEN_API_ENDPOINTS
 
+
+if CONFIG.config_file is None:
+    LOGGER.warning(
+        "Invalid config file or no config file provided, running server with default "
+        "settings. Errors: %s",
+        [
+            warnings.formatwarning(w.message, w.category, w.filename, w.lineno, "")
+            for w in config_warnings
+        ],
+    )
+else:
+    LOGGER.info("Loaded settings from %s.", CONFIG.config_file)
 
 if CONFIG.debug:  # pragma: no cover
     LOGGER.info("DEBUG MODE")

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -42,7 +42,7 @@ from aiida_optimade.utils import get_custom_base_url_path, OPEN_API_ENDPOINTS
 
 
 if CONFIG.config_file is None:
-    LOGGER.warning(
+    LOGGER.warning(  # pragma: no cover
         "Invalid config file or no config file provided, running server with default "
         "settings. Errors: %s",
         [
@@ -53,7 +53,7 @@ if CONFIG.config_file is None:
 else:
     LOGGER.info("Loaded settings from %s.", CONFIG.config_file)
 
-if CONFIG.debug:  # pragma: no cover
+if CONFIG.debug:
     LOGGER.info("DEBUG MODE")
 
 # Load AiiDA profile


### PR DESCRIPTION
Fixes #126

Use `get` method for dictionary property in `CONFIG`.

The `MANIFEST.in` will now include data JSON files in the source distribution.
The logging made in the `optimade` sample server will be done here as well for announcing which config file is being used, if any.

The CLI will automatically use the repo's `config.json` if the `OPTIMADE_CONFIG_FILE` environment variable is not found or does not point to an existing file.