### PR TITLE
Add `check-sdist-action` GH Action in new jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,3 +165,12 @@ jobs:
         port: 3253
         all versioned paths: yes
         validator version: v0.12.0
+
+  build-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check build and install source distribution
+        uses: CasperWA/check-sdist-action@v1


### PR DESCRIPTION
This will build the package's source distribution using `python setup.py sdist` and try to install the created archive.