### PR TITLE
Use aliases when handling response_fields

### DIFF
--- a/aiida_optimade/mappers/structures.py
+++ b/aiida_optimade/mappers/structures.py
@@ -18,6 +18,7 @@ class StructureMapper(ResourceMapper):
     TRANSLATOR = StructureDataTranslator
     ALL_ATTRIBUTES = set(StructureResourceAttributes.schema().get("properties").keys())
     REQUIRED_ATTRIBUTES = set(StructureResourceAttributes.schema().get("required"))
+    # This should be REQUIRED_FIELDS, but should be set as such in `optimade`
 
     @classmethod
     def build_attributes(cls, retrieved_attributes: dict, entry_pk: int) -> dict:

--- a/aiida_optimade/models/structures.py
+++ b/aiida_optimade/models/structures.py
@@ -7,11 +7,12 @@ from optimade.models import (
     StructureResource as OptimadeStructureResource,
     StructureResourceAttributes as OptimadeStructureResourceAttributes,
 )
-from optimade.server.config import CONFIG
 
 
 def prefix_provider(string: str) -> str:
     """Prefix string with `_{provider}_`"""
+    from optimade.server.config import CONFIG
+
     if string in CONFIG.provider_fields.get("structures", []):
         return f"_{CONFIG.provider.prefix}_{string}"
     return string

--- a/aiida_optimade/routers/utils.py
+++ b/aiida_optimade/routers/utils.py
@@ -77,7 +77,7 @@ def handle_response_fields(
     new_results = []
     while results:
         entry = results.pop(0)
-        new_entry = entry.dict(exclude=top_level, exclude_unset=True)
+        new_entry = entry.dict(exclude=top_level, exclude_unset=True, by_alias=True)
         for field in attribute_level:
             if field in new_entry["attributes"]:
                 del new_entry["attributes"][field]

--- a/tests/cli/test_calc.py
+++ b/tests/cli/test_calc.py
@@ -14,7 +14,7 @@ def test_calc_all_new(run_cli_command, aiida_profile, top_dir):
     # Clear database and get initialized_nodes.aiida
     aiida_profile.reset_db()
     archive = top_dir.joinpath("tests/cli/static/initialized_nodes.aiida")
-    import_data(archive, silent=True)
+    import_data(archive)
 
     fields = ["elements", "chemical_formula_hill"]
 
@@ -81,7 +81,7 @@ def test_calc_all_new(run_cli_command, aiida_profile, top_dir):
     # Repopulate database with the "proper" test data
     aiida_profile.reset_db()
     original_data = top_dir.joinpath("tests/static/test_structuredata.aiida")
-    import_data(original_data, silent=True)
+    import_data(original_data)
 
 
 def test_calc(run_cli_command, aiida_profile, top_dir):
@@ -95,7 +95,7 @@ def test_calc(run_cli_command, aiida_profile, top_dir):
     # Clear database and get initialized_nodes.aiida
     aiida_profile.reset_db()
     archive = top_dir.joinpath("tests/cli/static/initialized_nodes.aiida")
-    import_data(archive, silent=True)
+    import_data(archive)
 
     fields = ["elements", "chemical_formula_hill"]
 
@@ -139,4 +139,4 @@ def test_calc(run_cli_command, aiida_profile, top_dir):
     # Repopulate database with the "proper" test data
     aiida_profile.reset_db()
     original_data = top_dir.joinpath("tests/static/test_structuredata.aiida")
-    import_data(original_data, silent=True)
+    import_data(original_data)

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -14,7 +14,7 @@ def test_init(run_cli_command, aiida_profile, top_dir):
     aiida_profile.reset_db()
 
     archive = top_dir.joinpath("tests/cli/static/structure_data_nodes.aiida")
-    import_data(archive, silent=True)
+    import_data(archive)
 
     n_structure_data = orm.QueryBuilder().append(orm.StructureData).count()
 
@@ -64,4 +64,4 @@ def test_init(run_cli_command, aiida_profile, top_dir):
     # Repopulate database with the "proper" test data
     aiida_profile.reset_db()
     original_data = top_dir.joinpath("tests/static/test_structuredata.aiida")
-    import_data(original_data, silent=True)
+    import_data(original_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def aiida_profile(top_dir) -> TestManager:
             os.environ["AIIDA_PROFILE"] = profile
 
             filename = top_dir.joinpath("tests/static/test_structuredata.aiida")
-            import_data(filename, silent=True)
+            import_data(filename)
 
             yield manager
     finally:

--- a/tests/server/query_params/test_response_fields.py
+++ b/tests/server/query_params/test_response_fields.py
@@ -1,0 +1,45 @@
+def test_provider_fields(get_good_response):
+    """Ensure provider fields can be requested"""
+    from optimade.server.config import CONFIG
+
+    provider_specific_field = (
+        f"_{CONFIG.provider.prefix}_"
+        f"{CONFIG.provider_fields.get('structures', ['ctime'])[0]}"
+    )
+    request = f"/structures?response_fields={provider_specific_field}"
+    response = get_good_response(request)
+
+    returned_attributes = set()
+    for _ in response.get("data", []):
+        returned_attributes |= set(_.get("attributes", {}).keys())
+    assert returned_attributes == {
+        provider_specific_field,
+    }
+
+
+def test_non_provider_fields(get_good_response):
+    """Ensure provider fields are excluded when not requested"""
+    non_provider_specific_field = "elements"
+    request = f"/structures?response_fields={non_provider_specific_field}"
+    response = get_good_response(request)
+
+    returned_attributes = set()
+    for _ in response.get("data", []):
+        returned_attributes |= set(_.get("attributes", {}).keys())
+    assert returned_attributes == {
+        non_provider_specific_field,
+    }
+
+
+def test_wrong_alias_provider_fields(get_good_response):
+    """Ensure wrongly aliased provider fields are disregarded as unknown field"""
+    from optimade.server.config import CONFIG
+
+    wrongly_aliased_provider_field = CONFIG.provider_fields.get("structures", [])
+    request = f"/structures?response_fields={','.join(wrongly_aliased_provider_field)}"
+    response = get_good_response(request)
+
+    returned_attributes = set()
+    for _ in response.get("data", []):
+        returned_attributes |= set(_.get("attributes", {}).keys())
+    assert returned_attributes == set()


### PR DESCRIPTION
Fixes #149.
Fixes #157.

When handling `response_fields`, the dictionary created from the entry pydantic model is created using aliases, i.e., the provider-specific prefix is added correctly to `ctime` (and future provider-specific fields).
This ensures the resulting entries are correctly presented when `response_fields` is used.

As a note, there are some optimizations that should be possible when Materials-Consortia/optimade-python-tools#560 has been merged and released.