### PR TITLE
Use latest released validator version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       with:
         port: 3253
         all versioned paths: yes
-        validator version: v0.12.0
+        validator version: latest
 
   build-package:
     runs-on: ubuntu-latest

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -1,7 +1,3 @@
-import pytest
-
-
-@pytest.mark.skip("Does not work with optimade>=0.12.1")
 def test_with_validator(remote_client):
     """Validate server"""
     from optimade.validator import ImplementationValidator


### PR DESCRIPTION
Closes #123.

Run validator as part of pytest suite as well.