### PR TITLE
Don't use @calcfunction for CifData initialization

### DIFF
--- a/profiles/config.j2
+++ b/profiles/config.j2
@@ -1,6 +1,6 @@
 {
     "CONFIG_VERSION": {
-        "CURRENT": 3,
+        "CURRENT": 4,
         "OLDEST_COMPATIBLE": 3
     },
     "default_profile": "{{ aiida_profile }}",
@@ -11,10 +11,17 @@
             "AIIDADB_NAME": "{{ aiida_db_name }}",
             "AIIDADB_HOST": "{{ aiida_db_host }}",
             "AIIDADB_USER": "{{ aiida_db_user }}",
-            "AIIDADB_PORT": "{{ aiida_db_port }}",
+            "AIIDADB_PORT": {{ aiida_db_port }},
             "AIIDADB_BACKEND": "{{ aiida_db_backend }}",
             "default_user_email": "aiida@localhost",
-            "AIIDADB_REPOSITORY_URI": "file:///app/.aiida/repository-quicksetup"
+            "AIIDADB_REPOSITORY_URI": "file:///app/.aiida/repository-quicksetup",
+            "broker_protocol": "amqp",
+            "broker_username": "guest",
+            "broker_password": "guest",
+            "broker_host": "127.0.0.1",
+            "broker_port": 5672,
+            "broker_virtual_host": "",
+            "options": {}
         }
     }
 }

--- a/profiles/test_django.json
+++ b/profiles/test_django.json
@@ -1,6 +1,6 @@
 {
     "CONFIG_VERSION": {
-        "CURRENT": 3,
+        "CURRENT": 4,
         "OLDEST_COMPATIBLE": 3
     },
     "default_profile": "test_django",
@@ -11,10 +11,17 @@
             "AIIDADB_NAME": "test_django",
             "AIIDADB_HOST": "docker.host.internal",
             "AIIDADB_USER": "postgres",
-            "AIIDADB_PORT": "5432",
+            "AIIDADB_PORT": 5432,
             "AIIDADB_BACKEND": "django",
             "default_user_email": "aiida@localhost",
-            "AIIDADB_REPOSITORY_URI": "file:///app/.aiida/repository-quicksetup"
+            "AIIDADB_REPOSITORY_URI": "file:///app/.aiida/repository-quicksetup",
+            "broker_protocol": "amqp",
+            "broker_username": "guest",
+            "broker_password": "guest",
+            "broker_host": "127.0.0.1",
+            "broker_port": 5672,
+            "broker_virtual_host": "",
+            "options": {}
         }
     }
 }


### PR DESCRIPTION
There are two things in this PR:

1. Update AiiDA profile config template files to v4.
2. Avoid using an AiiDA `CalcFunction` for converting `CifData` to `StructureData` in-memory, in order to initalize/calculate the OPTIMADE fields for the Nodes.

The latter was suggested and outlined by @giovannipizzi.
It indeed speeds up the initialization by several orders of magnitude, but most importantly: It avoids the dependency on RabbitMQ for initializing `CifData` Nodes for the OPTIMADE server.