### PR TITLE
Use only 1 retrieval query for similar requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version}}
       uses: actions/setup-python@v2

--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -12,6 +12,7 @@ from optimade.server.config import CONFIG
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
 from aiida_optimade.common import CausationError
+from aiida_optimade.common.logger import LOGGER
 from aiida_optimade.mappers import ResourceMapper
 from aiida_optimade.transformers import AiidaTransformer
 from aiida_optimade.utils import retrieve_queryable_properties
@@ -49,6 +50,17 @@ class AiidaCollection:
         self._data_returned: int = None
         self._filter_fields: set = None
         self._latest_filter: dict = None
+        self._count: dict = None
+        self._checked_extras_filter_fields: set = set()
+
+    def _clear_cache(self) -> None:
+        """Clear in-memory attributes cache"""
+        self._data_available: int = None
+        self._data_returned: int = None
+        self._filter_fields: set = None
+        self._latest_filter: dict = None
+        self._count: dict = None
+        self._checked_extras_filter_fields: set = set()
 
     def get_attribute_fields(self) -> set:
         """Get all attribute properties/fields for OPTIMADE entity"""
@@ -92,17 +104,74 @@ class AiidaCollection:
 
     def _find_all(self, **kwargs) -> list:
         """Execute AiiDA QueryBuilder query, return all results."""
+        LOGGER.debug(
+            "Using QueryBuilder to get ALL projected values from found entries."
+        )
         query = self._find(self.entities, **kwargs)
         res = query.all()
         del query
         return res
 
-    def count(self, **kwargs) -> int:
-        """Count amount of data returned for query"""
+    def _perform_count(self, **kwargs) -> int:
+        """Instantiate new QueryBuilder object and perform count()"""
+        LOGGER.debug("Using QueryBuilder to COUNT all found entries.")
         query = self._find(self.entities, **kwargs)
         res = query.count()
         del query
         return res
+
+    def count(self, **kwargs) -> int:
+        """Count amount of data returned for query"""
+        LOGGER.debug("Calling count function in EntryCollection.")
+        if self._count is None:
+            LOGGER.debug("self._count is None")
+            self._count = {
+                "count": self._perform_count(**kwargs),
+                "filters": kwargs.get("filters", {}),
+                "limit": kwargs.get("limit", None),
+                "offset": kwargs.get("offset", None),
+            }
+        else:
+            for limiting_param in {"filters", "limit", "offset"}:
+                if kwargs.get(limiting_param, None) != self._count.get(
+                    limiting_param, None
+                ):
+                    if limiting_param == "filters":
+                        # As the `node_type` field is added to the filters in `_find()`,
+                        # this will make sure to check the _actual_ requested filter
+                        # fields.
+                        count_copy = self._count.get(limiting_param, {}).copy()
+                        kwargs_copy = kwargs.get(limiting_param, {}).copy()
+                        count_copy.pop("node_type", None)
+                        kwargs_copy.pop("node_type", None)
+                        if kwargs_copy == count_copy:
+                            continue
+                    elif limiting_param == "offset":
+                        if not kwargs.get(limiting_param, None) and not self._count.get(
+                            limiting_param, None
+                        ):
+                            # This will check also if offset in either is set to 0.
+                            # There is no difference if the default page_offset is
+                            # requested.
+                            continue
+                    LOGGER.debug(
+                        "%s was not the same as was found in self._count:\n"
+                        "self._count = %s\nkwargs = %s",
+                        limiting_param,
+                        self._count.get(limiting_param, None),
+                        kwargs.get(limiting_param, None),
+                    )
+                    self._count = {
+                        "count": self._perform_count(**kwargs),
+                        "filters": kwargs.get("filters", {}),
+                        "limit": kwargs.get("limit", None),
+                        "offset": kwargs.get("offset", None),
+                    }
+                    break
+            else:
+                LOGGER.debug("Using self._count")
+
+        return self._count.get("count", 0)
 
     @property
     def data_available(self) -> int:
@@ -116,7 +185,8 @@ class AiidaCollection:
     def set_data_available(self):
         """Set _data_available if it has not yet been set"""
         if not self._data_available:
-            self._data_available = self.count()
+            LOGGER.debug("Setting data_available!")
+            self._data_available = self.count(project="id")
 
     @property
     def data_returned(self) -> int:
@@ -140,7 +210,8 @@ class AiidaCollection:
             for key in ["limit", "offset"]:
                 if key in list(criteria.keys()):
                     del criteria[key]
-            self._latest_filter = criteria.get("filters", {})
+            self._latest_filter = criteria.get("filters", {}).copy()
+            LOGGER.debug("Setting data_returned using filter: %s", self._latest_filter)
             self._data_returned = self.count(**criteria)
 
     def find(
@@ -158,7 +229,26 @@ class AiidaCollection:
             fields = all_fields.copy()
 
         if criteria.get("filters", {}) and self._get_extras_filter_fields():
-            self._check_and_calculate_entities()
+            for requested_extras_field in self._get_extras_filter_fields():
+                if requested_extras_field not in self._checked_extras_filter_fields:
+                    LOGGER.debug(
+                        "Checking all extras fields have been calculated (and possibly "
+                        "calculate them)."
+                    )
+                    self._check_and_calculate_entities()
+                    self._checked_extras_filter_fields |= (
+                        self._get_extras_filter_fields()
+                    )
+                    break
+            else:
+                LOGGER.debug(
+                    "Not checking extras fields. Fields have already been checked."
+                )
+        else:
+            LOGGER.debug(
+                "Not checking extras fields. No filter and/or no extras fields "
+                "requested."
+            )
 
         self.set_data_returned(**criteria)
 
@@ -174,9 +264,10 @@ class AiidaCollection:
             )
 
         if isinstance(params, EntryListingQueryParams):
-            criteria_no_limit = criteria.copy()
-            criteria_no_limit.pop("limit", None)
-            more_data_available = len(results) < self.count(**criteria_no_limit)
+            criteria_copy = criteria.copy()
+            criteria_copy.pop("limit", None)
+            offset = criteria_copy.pop("offset", 0)
+            more_data_available = len(results) < (self.count(**criteria_copy) - offset)
         else:
             more_data_available = False
             if len(results) > 1:

--- a/tests/server/query_params/test_page_limit.py
+++ b/tests/server/query_params/test_page_limit.py
@@ -1,0 +1,81 @@
+"""Test the `page_limit` query parameter"""
+# pylint: disable=import-error,protected-access
+
+
+def test_limit(get_good_response):
+    """Check page_limit is respected"""
+    page_limit = [5, 10]
+    for limit in page_limit:
+        request = f"/structures?page_limit={limit}"
+        response = get_good_response(request)
+
+        assert len(response["data"]) == limit
+
+
+def test_count_limit(caplog):
+    """Test EntryCollection.count() when changing limit"""
+    from aiida_optimade.routers.structures import STRUCTURES
+
+    STRUCTURES._count = None
+
+    # The _count attribute should be None
+    limit = None
+    count_one = STRUCTURES.count(limit=limit)
+    assert "self._count is None" in caplog.text
+    assert "was not the same as was found in self._count" not in caplog.text
+    assert "Using self._count" not in caplog.text
+    caplog.clear()
+    assert STRUCTURES._count == {
+        "count": count_one,
+        "filters": {},
+        "limit": limit,
+        "offset": None,
+    }
+
+    # Changing limit to an int. This should result in a new QueryBuilder call
+    limit = 5
+    count_two = STRUCTURES.count(limit=limit)
+    assert "self._count is None" not in caplog.text
+    assert "limit was not the same as was found in self._count" in caplog.text
+    assert "Using self._count" not in caplog.text
+    assert count_two == limit
+    caplog.clear()
+    assert STRUCTURES._count == {
+        "count": count_two,
+        "filters": {},
+        "limit": limit,
+        "offset": None,
+    }
+
+    # Keeping the same limit. This should not result in a new QueryBuilder call
+    count_three = STRUCTURES.count(limit=limit)
+    assert "self._count is None" not in caplog.text
+    assert "was not the same as was found in self._count" not in caplog.text
+    assert "Using self._count" in caplog.text
+    assert count_two == count_three
+    assert STRUCTURES._count == {
+        "count": count_three,
+        "filters": {},
+        "limit": limit,
+        "offset": None,
+    }
+
+
+def test_page_limit_max(get_good_response, check_error_response):
+    """Ensure the configuration page_limit_max is respected"""
+    from optimade.server.config import CONFIG
+
+    request = f"/structures?page_limit={CONFIG.page_limit_max}"
+    response = get_good_response(request)
+    assert len(response["data"]) == CONFIG.page_limit_max
+
+    request = f"/structures?page_limit={CONFIG.page_limit_max + 1}"
+    check_error_response(
+        request,
+        expected_status=403,
+        expected_title="HTTPException",
+        expected_detail=(
+            f"Max allowed page_limit is {CONFIG.page_limit_max}, you requested "
+            f"{CONFIG.page_limit_max + 1}"
+        ),
+    )

--- a/tests/server/query_params/test_page_offset.py
+++ b/tests/server/query_params/test_page_offset.py
@@ -1,0 +1,73 @@
+"""Test the `page_offset` query parameter"""
+# pylint: disable=import-error,protected-access
+
+
+def test_offset(get_good_response):
+    """Apply low offset, comparing two requests with and without offset"""
+    page_limit = 5
+    request = f"/structures?page_offset=0&page_limit={page_limit}&sort=immutable_id"
+    response = get_good_response(request)
+    first_response_uuids = [_["attributes"]["immutable_id"] for _ in response["data"]]
+
+    assert len(first_response_uuids) == page_limit
+
+    offset = 2
+    request = (
+        f"/structures?page_offset={offset}&page_limit={page_limit - offset}"
+        "&sort=immutable_id"
+    )
+    expected_uuids = first_response_uuids[offset:]
+    response = get_good_response(request)
+
+    assert len(response["data"]) == len(expected_uuids)
+    assert expected_uuids == [_["attributes"]["immutable_id"] for _ in response["data"]]
+
+
+def test_count_offset(caplog):
+    """Test EntryCollection.count() when changing offset"""
+    from aiida_optimade.routers.structures import STRUCTURES
+
+    STRUCTURES._count = None
+
+    # The _count attribute should be None
+    offset = None
+    count_one = STRUCTURES.count(offset=offset)
+    assert "self._count is None" in caplog.text
+    assert "was not the same as was found in self._count" not in caplog.text
+    assert "Using self._count" not in caplog.text
+    caplog.clear()
+    assert STRUCTURES._count == {
+        "count": count_one,
+        "filters": {},
+        "limit": None,
+        "offset": offset,
+    }
+
+    # Changing offset to 0 shouldn't result in a new QueryBuilder call
+    offset = 0
+    count_two = STRUCTURES.count(offset=offset)
+    assert "self._count is None" not in caplog.text
+    assert "was not the same as was found in self._count" not in caplog.text
+    assert "Using self._count" in caplog.text
+    caplog.clear()
+    assert count_one == count_two
+    assert STRUCTURES._count == {
+        "count": count_two,
+        "filters": {},
+        "limit": None,
+        "offset": None,  # This shouldn't be updated to 0
+    }
+
+    # Changing offset to a non-zero value. This should result in a new QueryBuilder call
+    offset = 2
+    count_three = STRUCTURES.count(offset=offset)
+    assert "self._count is None" not in caplog.text
+    assert "offset was not the same as was found in self._count" in caplog.text
+    assert "Using self._count" not in caplog.text
+    assert count_two == count_three + offset
+    assert STRUCTURES._count == {
+        "count": count_three,
+        "filters": {},
+        "limit": None,
+        "offset": offset,
+    }


### PR DESCRIPTION
As it stands 4 `QueryBuilder` queries are performed during the absolute first query of a server's lifetime.
After that only 3 queries are performed.

If a filter is included and it targets a calculated OPTIMADE field stored in the Nodes' extras, another query will be added (5 then 4).

This PR drops the queries performed per request substantially to a minimum of 1 query per request.

This is done by manually subtracting `offset` from the counted results of the query when determining whether there are `more_data_available`.

It also now stores the latest count and checks whether an option is supplied to the query that would alter it (`filters`, `limit`, `offset`). If any of these have changed since the last time count was called it will call count again.
This also takes into account if there is a change, but the default value is used. E.g., if `page_offset` was not used in the original request (storing a `None` value in the server), but then it's set to `0` in a subsequent request (without altering anything else about the request). This will not change the result of counting, since an offset of value `0` is the default, hence equivalent to `None`.

Finally, the checked extras fields are now stored. So if a filter is given which filters on an OPTIMADE field that is calculated and stored in the Nodes' extras, it will be checked (resulting in a `QueryBuilder` query) and stored in a `set`. All subsequent requests that filters on the same OPTIMADE fields will not result in a new `QueryBuilder` query to check whether the fields are present in all Nodes' extras (since this has already now been checked and confirmed).
**Note**: This also means that one should restart a server after changing the served database if, e.g., new Nodes are added.