### PR TITLE
Remove dependencies gotten from aiida-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,11 @@ optimade[mongo]~=0.14.0
 pymatgen~=2021.3
 uvicorn~=0.13.4
 
-# Dependencies included through `aiida-core`:
+# Dependencies used directly in this package, but included through other dependencies:
+# aiida-core:
 #   click
 #   click-completion
 #   tqdm
+# optimade:
+#   pydantic
+#   fastapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 aiida-core~=1.6.3
-click~=7.1
-click-completion~=0.5.2
 optimade[mongo]~=0.14.0
 pymatgen~=2021.3
-tqdm~=4.60
 uvicorn~=0.13.4
+
+# Dependencies included through `aiida-core`:
+#   click
+#   click-completion
+#   tqdm


### PR DESCRIPTION
Since both `click`, `click-completion`, and `tqdm` are core dependencies of `aiida-core` (AiiDA), it makes sense to get these directly from what is supported in AiiDA, instead of trying to support only newer versions in the current package.

In order to make clear what packages that are dependencies of `aiida-core`, but are still used directly in this package, a comment with a list of these dependencies have been added to `requirements.txt`. Should they ever be moved out of AiiDA's core dependencies they should be added back to this package explicitly.