### PR TITLE
Dependencies: put upper limit markupsafe<2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiida-core~=1.6.5
 optimade[mongo]~=0.16.10
 pymatgen~=2021.3
 uvicorn~=0.17.4
+markupsafe<2.1
 
 # Dependencies used directly in this package, but included through other dependencies:
 # aiida-core:


### PR DESCRIPTION
The latest release `markupsafe==2.1` breaks `jinja<3.0` and that in
turn breaks `click`.