### PR TITLE
Data curation with configure parameter `query_group`

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -110,7 +110,7 @@ jobs:
         AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
         AIIDA_PROFILE: test_${{ matrix.backend }}
         PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
-      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20 tests/server/routers/test_structures.py::TestStructuresGroupEndpoint
+      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -92,7 +92,7 @@ jobs:
                   AIIDA_TEST_BACKEND: ${{ matrix.backend }}
                   AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
                   AIIDA_PROFILE: test_${{ matrix.backend }}
-              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:coverage.xml --durations=20
+              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20
 
             - name: Test with pytest (Data Curation)
               env:
@@ -100,7 +100,7 @@ jobs:
                   AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
                   AIIDA_PROFILE: test_${{ matrix.backend }}
                   PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
-              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:coverage.xml --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
+              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --cov-append --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
             - name: Test with pytest (MongoDB)
               env:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -110,7 +110,7 @@ jobs:
         AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
         AIIDA_PROFILE: test_${{ matrix.backend }}
         PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
-      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
+      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --cov-append --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -92,7 +92,15 @@ jobs:
                   AIIDA_TEST_BACKEND: ${{ matrix.backend }}
                   AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
                   AIIDA_PROFILE: test_${{ matrix.backend }}
-              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20
+              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:coverage.xml --durations=20
+
+            - name: Test with pytest (Data Curation)
+              env:
+                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+                  AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+                  AIIDA_PROFILE: test_${{ matrix.backend }}
+                  PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
+              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:coverage.xml --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
             - name: Test with pytest (MongoDB)
               env:
@@ -103,14 +111,6 @@ jobs:
                   OPTIMADE_MONGO_URI: mongodb://localhost:27017
                   OPTIMADE_DATABASE_BACKEND: mongodb
               run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:mongo_cov.xml --durations=20
-
-    # - name: Test with pytest (Data Curation)
-    #   env:
-    #     AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-    #     AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
-    #     AIIDA_PROFILE: test_${{ matrix.backend }}
-    #     PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
-    #   run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --cov-append --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
             - name: Upload coverage to Codecov
               if: matrix.python-version == 3.8

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,340 +10,348 @@ on:
 
 jobs:
 
-    pre-commit:
-        runs-on: ubuntu-latest
-        timeout-minutes: 2
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
 
-        steps:
-            - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-            - name: Set up Python 3.8
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.8
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
 
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install -U setuptools
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools
 
-                  while IFS="" read -r line || [ -n "${line}" ]; do
-                      if [[ "${line}" =~ ^pre-commit.*$ ]]; then
-                          pre_commit="${line}"
-                      fi
-                  done < requirements_dev.txt
+        while IFS="" read -r line || [ -n "${line}" ]; do
+            if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+                pre_commit="${line}"
+            fi
+        done < requirements_dev.txt
 
-                  pip install ${pre_commit}
+        pip install ${pre_commit}
 
-            - name: Test with pre-commit
-              run: SKIP=codecov-validator pre-commit run --all-files --show-diff-on-failure
+    - name: Test with pre-commit
+      run: SKIP=codecov-validator pre-commit run --all-files --show-diff-on-failure
 
-    pytest:
-        runs-on: ubuntu-latest
-        timeout-minutes: 20
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
 
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: ['3.8', '3.9', '3.10']
-                backend: [psql_dos]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+        backend: ['psql_dos']
 
-        services:
-            mongo:
-                image: mongo:4
-                ports:
-                    - 27017:27017
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_DB: test_${{ matrix.backend }}
-                    POSTGRES_PASSWORD: test
-                options: >-
-                    --health-cmd pg_isready
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
-                ports:
-                    - 5432:5432
+    services:
+      mongo:
+        image: mongo:4
+        ports:
+          - 27017:27017
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  fetch-depth: 2
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
 
-            - name: Set up Python ${{ matrix.python-version}}
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ matrix.python-version}}
+    - name: Set up Python ${{ matrix.python-version}}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version}}
 
-            - name: Install python dependencies
-              run: |
-                  python -m pip install -U pip
-                  pip install -U setuptools
-                  pip install -e .[testing]
+    - name: Install python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools
+        pip install -e .[testing]
 
-            - name: Setup up environment for AiiDA
-              env:
-                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-              run: .github/aiida/setup_aiida.sh
+    - name: Setup up environment for AiiDA
+      env:
+        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+      run: .github/aiida/setup_aiida.sh
 
-            - name: Test with pytest (AiiDA)
-              env:
-                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-                  AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
-                  AIIDA_PROFILE: test_${{ matrix.backend }}
-              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20
+    - name: Test with pytest (AiiDA)
+      env:
+        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+        AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+        AIIDA_PROFILE: test_${{ matrix.backend }}
+      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20
 
-            - name: Test with pytest (MongoDB)
-              env:
-                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-                  AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
-                  AIIDA_PROFILE: test_${{ matrix.backend }}
-                  PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_mongo_config.json
-                  OPTIMADE_MONGO_URI: mongodb://localhost:27017
-                  OPTIMADE_DATABASE_BACKEND: mongodb
-              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:mongo_cov.xml --durations=20
+    - name: Test with pytest (MongoDB)
+      env:
+        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+        AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+        AIIDA_PROFILE: test_${{ matrix.backend }}
+        PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_mongo_config.json
+        OPTIMADE_MONGO_URI: mongodb://localhost:27017
+        OPTIMADE_DATABASE_BACKEND: mongodb
+      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:mongo_cov.xml --durations=20
 
-            - name: Upload coverage to Codecov
-              if: matrix.python-version == 3.8
-              uses: codecov/codecov-action@v3
-              with:
-                  flags: aiida
-                  file: ./coverage.xml
+    - name: Test with pytest (Data Curation)
+      env:
+        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+        AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+        AIIDA_PROFILE: test_${{ matrix.backend }}
+        PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
+      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20 tests/server/routers/test_structures.py::TestStructuresGroupEndpoint
 
-            - name: Upload coverage to Codecov
-              if: matrix.python-version == 3.8
-              uses: codecov/codecov-action@v3
-              with:
-                  flags: mongo
-                  file: ./mongo_cov.xml
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.8
+      uses: codecov/codecov-action@v3
+      with:
+        flags: aiida
+        file: ./coverage.xml
 
-    docker:
-        runs-on: ubuntu-latest
-        timeout-minutes: 14
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.8
+      uses: codecov/codecov-action@v3
+      with:
+        flags: mongo
+        file: ./mongo_cov.xml
 
-        strategy:
-            fail-fast: false
-            matrix:
-                database: [aiida, mongo]
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 14
 
-        services:
-            mongo:
-                image: mongo:4
-                ports:
-                    - 27017:27017
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_DB: test_psql_dos
-                    POSTGRES_PASSWORD: test
-                options: >-
-                    --health-cmd pg_isready
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
-                ports:
-                    - 5432:5432
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ['aiida', 'mongo']
 
-        steps:
-            - uses: actions/checkout@v3
+    services:
+      mongo:
+        image: mongo:4
+        ports:
+        - 27017:27017
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_DB: test_psql_dos
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
-            - name: Set up Python 3.8
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.8
+    steps:
+    - uses: actions/checkout@v3
 
-            - name: Install python dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install -U setuptools
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
 
-                  while IFS="" read -r line || [ -n "${line}" ]; do
-                      if [[ "${line}" =~ ^aiida-core.*$ ]]; then
-                          aiida_core="${line}"
-                      fi
-                  done < requirements.txt
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools
 
-                  pip install ${aiida_core}
+        while IFS="" read -r line || [ -n "${line}" ]; do
+            if [[ "${line}" =~ ^aiida-core.*$ ]]; then
+                aiida_core="${line}"
+            fi
+        done < requirements.txt
 
-                  pip install pymongo
+        pip install ${aiida_core}
 
-            - name: Setup up environment for AiiDA
-              env:
-                  AIIDA_TEST_BACKEND: psql_dos
-              run: .github/aiida/setup_aiida.sh
+        pip install pymongo
 
-            - name: Load test data
-              run: |
-                  if [ "${{ matrix.database }}" == "aiida" ]; then
-                    verdi archive import --migration .github/aiida/optimade.aiida
-                  else
-                      .github/mongo/load_data.py
-                  fi
+    - name: Setup up environment for AiiDA
+      env:
+        AIIDA_TEST_BACKEND: psql_dos
+      run: .github/aiida/setup_aiida.sh
 
-            - name: Build docker image
-              if: matrix.database == 'mongo'
-              run: docker-compose -f profiles/docker-compose.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
+    - name: Load test data
+      run: |
+        if [ "${{ matrix.database }}" == "aiida" ]; then
+          verdi archive import --migration .github/aiida/optimade.aiida
+        else
+            .github/mongo/load_data.py
+        fi
 
-            - name: Start the Docker image
-              env:
-                  AIIDA_OPTIMADE_LOG_LEVEL: DEBUG
-              run: |
-                  export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
-                  docker-compose -f profiles/docker-compose.yml up &
-                  .github/utils/wait_for_it.sh localhost:3253 -t 360
-                  sleep 15
+    - name: Build docker image
+      if: matrix.database == 'mongo'
+      run: docker-compose -f profiles/docker-compose.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
 
-            - name: Test server with OPTIMADE Validator
-              uses: Materials-Consortia/optimade-validator-action@v2
-              with:
-                  port: 3253
-                  all versioned paths: yes
-                  validate unversioned path: yes
-                  validator version: latest
+    - name: Start the Docker image
+      env:
+        AIIDA_OPTIMADE_LOG_LEVEL: DEBUG
+      run: |
+        export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
+        docker-compose -f profiles/docker-compose.yml up &
+        .github/utils/wait_for_it.sh localhost:3253 -t 360
+        sleep 15
 
-    docker-mongo:
-        runs-on: ubuntu-latest
-        timeout-minutes: 14
+    - name: Test server with OPTIMADE Validator
+      uses: Materials-Consortia/optimade-validator-action@v2
+      with:
+        port: 3253
+        all versioned paths: yes
+        validate unversioned path: yes
+        validator version: latest
 
-        services:
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_DB: test_psql_dos
-                    POSTGRES_PASSWORD: test
-                options: >-
-                    --health-cmd pg_isready
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
-                ports:
-                    - 5432:5432
+  docker-mongo:
+    runs-on: ubuntu-latest
+    timeout-minutes: 14
 
-        steps:
-            - uses: actions/checkout@v3
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_DB: test_psql_dos
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
-            - name: Set up Python 3.8
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.8
+    steps:
+    - uses: actions/checkout@v3
 
-            - name: Install python dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install -U setuptools
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
 
-                  while IFS="" read -r line || [ -n "${line}" ]; do
-                      if [[ "${line}" =~ ^aiida-core.*$ ]]; then
-                          aiida_core="${line}"
-                      fi
-                  done < requirements.txt
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools
 
-                  pip install ${aiida_core}
+        while IFS="" read -r line || [ -n "${line}" ]; do
+            if [[ "${line}" =~ ^aiida-core.*$ ]]; then
+                aiida_core="${line}"
+            fi
+        done < requirements.txt
 
-            - name: Setup up environment for AiiDA
-              env:
-                  AIIDA_TEST_BACKEND: psql_dos
-              run: .github/aiida/setup_aiida.sh
+        pip install ${aiida_core}
 
-            - name: Load test data (AiiDA)
-              run: verdi archive import --migration .github/aiida/optimade.aiida
+    - name: Setup up environment for AiiDA
+      env:
+        AIIDA_TEST_BACKEND: psql_dos
+      run: .github/aiida/setup_aiida.sh
 
-            - name: Build docker image
-              run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
+    - name: Load test data (AiiDA)
+      run: verdi archive import --migration .github/aiida/optimade.aiida
 
-            - name: Start the Docker image
-              env:
-                  AIIDA_OPTIMADE_LOG_LEVEL: INFO
-                  USE_MONGO: --mongo
-              run: |
-                  export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
-                  docker-compose -f profiles/docker-compose-mongo.yml up &
-                  .github/utils/wait_for_it.sh localhost:3253 -t 360
-                  # Long sleep, because the initialization is needed
-                  sleep 150
+    - name: Build docker image
+      run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
 
-            - name: Test server with OPTIMADE Validator
-              uses: Materials-Consortia/optimade-validator-action@v2
-              with:
-                  port: 3253
-                  all versioned paths: yes
-                  validate unversioned path: yes
-                  validator version: latest
+    - name: Start the Docker image
+      env:
+        AIIDA_OPTIMADE_LOG_LEVEL: INFO
+        USE_MONGO: '--mongo'
+      run: |
+        export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
+        docker-compose -f profiles/docker-compose-mongo.yml up &
+        .github/utils/wait_for_it.sh localhost:3253 -t 360
+        # Long sleep, because the initialization is needed
+        sleep 150
 
-    docker-mongo-filename:
-        runs-on: ubuntu-latest
-        timeout-minutes: 14
+    - name: Test server with OPTIMADE Validator
+      uses: Materials-Consortia/optimade-validator-action@v2
+      with:
+        port: 3253
+        all versioned paths: yes
+        validate unversioned path: yes
+        validator version: latest
 
-        services:
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_DB: test_psql_dos
-                    POSTGRES_PASSWORD: test
-                options: >-
-                    --health-cmd pg_isready
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
-                ports:
-                    - 5432:5432
+  docker-mongo-filename:
+    runs-on: ubuntu-latest
+    timeout-minutes: 14
 
-        steps:
-            - uses: actions/checkout@v3
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_DB: test_psql_dos
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
-            - name: Set up Python 3.8
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.8
+    steps:
+    - uses: actions/checkout@v3
 
-            - name: Install python dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install -U setuptools
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
 
-                  while IFS="" read -r line || [ -n "${line}" ]; do
-                      if [[ "${line}" =~ ^aiida-core.*$ ]]; then
-                          aiida_core="${line}"
-                      fi
-                  done < requirements.txt
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools
 
-                  pip install ${aiida_core}
+        while IFS="" read -r line || [ -n "${line}" ]; do
+            if [[ "${line}" =~ ^aiida-core.*$ ]]; then
+                aiida_core="${line}"
+            fi
+        done < requirements.txt
 
-            - name: Setup up environment for AiiDA
-              env:
-                  AIIDA_TEST_BACKEND: psql_dos
-              run: .github/aiida/setup_aiida.sh
+        pip install ${aiida_core}
 
-            - name: Build docker image
-              run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
+    - name: Setup up environment for AiiDA
+      env:
+        AIIDA_TEST_BACKEND: psql_dos
+      run: .github/aiida/setup_aiida.sh
 
-            - name: Start the Docker image
-              env:
-                  AIIDA_OPTIMADE_LOG_LEVEL: INFO
-                  USE_MONGO: --mongo
-                  MONGO_FILENAME: test_structures_mongo.json
-              run: |
-                  export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
-                  docker-compose -f profiles/docker-compose-mongo.yml up &
-                  .github/utils/wait_for_it.sh localhost:3253 -t 360
-                  # Longer sleep, because the initialization is needed
-                  sleep 30
+    - name: Build docker image
+      run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
 
-            - name: Test server with OPTIMADE Validator
-              uses: Materials-Consortia/optimade-validator-action@v2
-              with:
-                  port: 3253
-                  all versioned paths: yes
-                  validate unversioned path: yes
-                  validator version: latest
+    - name: Start the Docker image
+      env:
+        AIIDA_OPTIMADE_LOG_LEVEL: INFO
+        USE_MONGO: '--mongo'
+        MONGO_FILENAME: test_structures_mongo.json
+      run: |
+        export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
+        docker-compose -f profiles/docker-compose-mongo.yml up &
+        .github/utils/wait_for_it.sh localhost:3253 -t 360
+        # Longer sleep, because the initialization is needed
+        sleep 30
 
-    build-package:
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
+    - name: Test server with OPTIMADE Validator
+      uses: Materials-Consortia/optimade-validator-action@v2
+      with:
+        port: 3253
+        all versioned paths: yes
+        validate unversioned path: yes
+        validator version: latest
 
-        steps:
-            - uses: actions/checkout@v3
+  build-package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
-            - name: Check build and install source distribution
-              uses: CasperWA/check-sdist-action@v1
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check build and install source distribution
+        uses: CasperWA/check-sdist-action@v1

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,99 +10,99 @@ on:
 
 jobs:
 
-  pre-commit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
+    pre-commit:
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
 
-    steps:
-    - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
+            - name: Set up Python 3.8
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.8
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -U setuptools
 
-        while IFS="" read -r line || [ -n "${line}" ]; do
-            if [[ "${line}" =~ ^pre-commit.*$ ]]; then
-                pre_commit="${line}"
-            fi
-        done < requirements_dev.txt
+                  while IFS="" read -r line || [ -n "${line}" ]; do
+                      if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+                          pre_commit="${line}"
+                      fi
+                  done < requirements_dev.txt
 
-        pip install ${pre_commit}
+                  pip install ${pre_commit}
 
-    - name: Test with pre-commit
-      run: SKIP=codecov-validator pre-commit run --all-files --show-diff-on-failure
+            - name: Test with pre-commit
+              run: SKIP=codecov-validator pre-commit run --all-files --show-diff-on-failure
 
-  pytest:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    pytest:
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        backend: ['psql_dos']
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: ['3.8', '3.9', '3.10']
+                backend: [psql_dos]
 
-    services:
-      mongo:
-        image: mongo:4
-        ports:
-          - 27017:27017
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_DB: test_${{ matrix.backend }}
-          POSTGRES_PASSWORD: test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
+        services:
+            mongo:
+                image: mongo:4
+                ports:
+                    - 27017:27017
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_DB: test_${{ matrix.backend }}
+                    POSTGRES_PASSWORD: test
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                ports:
+                    - 5432:5432
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 2
 
-    - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version}}
+            - name: Set up Python ${{ matrix.python-version}}
+              uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version}}
 
-    - name: Install python dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools
-        pip install -e .[testing]
+            - name: Install python dependencies
+              run: |
+                  python -m pip install -U pip
+                  pip install -U setuptools
+                  pip install -e .[testing]
 
-    - name: Setup up environment for AiiDA
-      env:
-        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-      run: .github/aiida/setup_aiida.sh
+            - name: Setup up environment for AiiDA
+              env:
+                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+              run: .github/aiida/setup_aiida.sh
 
-    - name: Test with pytest (AiiDA)
-      env:
-        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-        AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
-        AIIDA_PROFILE: test_${{ matrix.backend }}
-      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20
+            - name: Test with pytest (AiiDA)
+              env:
+                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+                  AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+                  AIIDA_PROFILE: test_${{ matrix.backend }}
+              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --durations=20
 
-    - name: Test with pytest (MongoDB)
-      env:
-        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-        AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
-        AIIDA_PROFILE: test_${{ matrix.backend }}
-        PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_mongo_config.json
-        OPTIMADE_MONGO_URI: mongodb://localhost:27017
-        OPTIMADE_DATABASE_BACKEND: mongodb
-      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:mongo_cov.xml --durations=20
+            - name: Test with pytest (MongoDB)
+              env:
+                  AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+                  AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+                  AIIDA_PROFILE: test_${{ matrix.backend }}
+                  PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_mongo_config.json
+                  OPTIMADE_MONGO_URI: mongodb://localhost:27017
+                  OPTIMADE_DATABASE_BACKEND: mongodb
+              run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:mongo_cov.xml --durations=20
 
     # - name: Test with pytest (Data Curation)
     #   env:
@@ -112,246 +112,246 @@ jobs:
     #     PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
     #   run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --cov-append --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.8
-      uses: codecov/codecov-action@v3
-      with:
-        flags: aiida
-        file: ./coverage.xml
+            - name: Upload coverage to Codecov
+              if: matrix.python-version == 3.8
+              uses: codecov/codecov-action@v3
+              with:
+                  flags: aiida
+                  file: ./coverage.xml
 
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.8
-      uses: codecov/codecov-action@v3
-      with:
-        flags: mongo
-        file: ./mongo_cov.xml
+            - name: Upload coverage to Codecov
+              if: matrix.python-version == 3.8
+              uses: codecov/codecov-action@v3
+              with:
+                  flags: mongo
+                  file: ./mongo_cov.xml
 
-  docker:
-    runs-on: ubuntu-latest
-    timeout-minutes: 14
+    docker:
+        runs-on: ubuntu-latest
+        timeout-minutes: 14
 
-    strategy:
-      fail-fast: false
-      matrix:
-        database: ['aiida', 'mongo']
+        strategy:
+            fail-fast: false
+            matrix:
+                database: [aiida, mongo]
 
-    services:
-      mongo:
-        image: mongo:4
-        ports:
-        - 27017:27017
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_DB: test_psql_dos
-          POSTGRES_PASSWORD: test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
+        services:
+            mongo:
+                image: mongo:4
+                ports:
+                    - 27017:27017
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_DB: test_psql_dos
+                    POSTGRES_PASSWORD: test
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                ports:
+                    - 5432:5432
 
-    steps:
-    - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
+            - name: Set up Python 3.8
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.8
 
-    - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools
+            - name: Install python dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -U setuptools
 
-        while IFS="" read -r line || [ -n "${line}" ]; do
-            if [[ "${line}" =~ ^aiida-core.*$ ]]; then
-                aiida_core="${line}"
-            fi
-        done < requirements.txt
+                  while IFS="" read -r line || [ -n "${line}" ]; do
+                      if [[ "${line}" =~ ^aiida-core.*$ ]]; then
+                          aiida_core="${line}"
+                      fi
+                  done < requirements.txt
 
-        pip install ${aiida_core}
+                  pip install ${aiida_core}
 
-        pip install pymongo
+                  pip install pymongo
 
-    - name: Setup up environment for AiiDA
-      env:
-        AIIDA_TEST_BACKEND: psql_dos
-      run: .github/aiida/setup_aiida.sh
+            - name: Setup up environment for AiiDA
+              env:
+                  AIIDA_TEST_BACKEND: psql_dos
+              run: .github/aiida/setup_aiida.sh
 
-    - name: Load test data
-      run: |
-        if [ "${{ matrix.database }}" == "aiida" ]; then
-          verdi archive import --migration .github/aiida/optimade.aiida
-        else
-            .github/mongo/load_data.py
-        fi
+            - name: Load test data
+              run: |
+                  if [ "${{ matrix.database }}" == "aiida" ]; then
+                    verdi archive import --migration .github/aiida/optimade.aiida
+                  else
+                      .github/mongo/load_data.py
+                  fi
 
-    - name: Build docker image
-      if: matrix.database == 'mongo'
-      run: docker-compose -f profiles/docker-compose.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
+            - name: Build docker image
+              if: matrix.database == 'mongo'
+              run: docker-compose -f profiles/docker-compose.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
 
-    - name: Start the Docker image
-      env:
-        AIIDA_OPTIMADE_LOG_LEVEL: DEBUG
-      run: |
-        export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
-        docker-compose -f profiles/docker-compose.yml up &
-        .github/utils/wait_for_it.sh localhost:3253 -t 360
-        sleep 15
+            - name: Start the Docker image
+              env:
+                  AIIDA_OPTIMADE_LOG_LEVEL: DEBUG
+              run: |
+                  export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
+                  docker-compose -f profiles/docker-compose.yml up &
+                  .github/utils/wait_for_it.sh localhost:3253 -t 360
+                  sleep 15
 
-    - name: Test server with OPTIMADE Validator
-      uses: Materials-Consortia/optimade-validator-action@v2
-      with:
-        port: 3253
-        all versioned paths: yes
-        validate unversioned path: yes
-        validator version: latest
+            - name: Test server with OPTIMADE Validator
+              uses: Materials-Consortia/optimade-validator-action@v2
+              with:
+                  port: 3253
+                  all versioned paths: yes
+                  validate unversioned path: yes
+                  validator version: latest
 
-  docker-mongo:
-    runs-on: ubuntu-latest
-    timeout-minutes: 14
+    docker-mongo:
+        runs-on: ubuntu-latest
+        timeout-minutes: 14
 
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_DB: test_psql_dos
-          POSTGRES_PASSWORD: test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
+        services:
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_DB: test_psql_dos
+                    POSTGRES_PASSWORD: test
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                ports:
+                    - 5432:5432
 
-    steps:
-    - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
+            - name: Set up Python 3.8
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.8
 
-    - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools
+            - name: Install python dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -U setuptools
 
-        while IFS="" read -r line || [ -n "${line}" ]; do
-            if [[ "${line}" =~ ^aiida-core.*$ ]]; then
-                aiida_core="${line}"
-            fi
-        done < requirements.txt
+                  while IFS="" read -r line || [ -n "${line}" ]; do
+                      if [[ "${line}" =~ ^aiida-core.*$ ]]; then
+                          aiida_core="${line}"
+                      fi
+                  done < requirements.txt
 
-        pip install ${aiida_core}
+                  pip install ${aiida_core}
 
-    - name: Setup up environment for AiiDA
-      env:
-        AIIDA_TEST_BACKEND: psql_dos
-      run: .github/aiida/setup_aiida.sh
+            - name: Setup up environment for AiiDA
+              env:
+                  AIIDA_TEST_BACKEND: psql_dos
+              run: .github/aiida/setup_aiida.sh
 
-    - name: Load test data (AiiDA)
-      run: verdi archive import --migration .github/aiida/optimade.aiida
+            - name: Load test data (AiiDA)
+              run: verdi archive import --migration .github/aiida/optimade.aiida
 
-    - name: Build docker image
-      run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
+            - name: Build docker image
+              run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
 
-    - name: Start the Docker image
-      env:
-        AIIDA_OPTIMADE_LOG_LEVEL: INFO
-        USE_MONGO: '--mongo'
-      run: |
-        export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
-        docker-compose -f profiles/docker-compose-mongo.yml up &
-        .github/utils/wait_for_it.sh localhost:3253 -t 360
-        # Long sleep, because the initialization is needed
-        sleep 150
+            - name: Start the Docker image
+              env:
+                  AIIDA_OPTIMADE_LOG_LEVEL: INFO
+                  USE_MONGO: --mongo
+              run: |
+                  export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
+                  docker-compose -f profiles/docker-compose-mongo.yml up &
+                  .github/utils/wait_for_it.sh localhost:3253 -t 360
+                  # Long sleep, because the initialization is needed
+                  sleep 150
 
-    - name: Test server with OPTIMADE Validator
-      uses: Materials-Consortia/optimade-validator-action@v2
-      with:
-        port: 3253
-        all versioned paths: yes
-        validate unversioned path: yes
-        validator version: latest
+            - name: Test server with OPTIMADE Validator
+              uses: Materials-Consortia/optimade-validator-action@v2
+              with:
+                  port: 3253
+                  all versioned paths: yes
+                  validate unversioned path: yes
+                  validator version: latest
 
-  docker-mongo-filename:
-    runs-on: ubuntu-latest
-    timeout-minutes: 14
+    docker-mongo-filename:
+        runs-on: ubuntu-latest
+        timeout-minutes: 14
 
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_DB: test_psql_dos
-          POSTGRES_PASSWORD: test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
+        services:
+            postgres:
+                image: postgres:12
+                env:
+                    POSTGRES_DB: test_psql_dos
+                    POSTGRES_PASSWORD: test
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+                ports:
+                    - 5432:5432
 
-    steps:
-    - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
+            - name: Set up Python 3.8
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.8
 
-    - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools
+            - name: Install python dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -U setuptools
 
-        while IFS="" read -r line || [ -n "${line}" ]; do
-            if [[ "${line}" =~ ^aiida-core.*$ ]]; then
-                aiida_core="${line}"
-            fi
-        done < requirements.txt
+                  while IFS="" read -r line || [ -n "${line}" ]; do
+                      if [[ "${line}" =~ ^aiida-core.*$ ]]; then
+                          aiida_core="${line}"
+                      fi
+                  done < requirements.txt
 
-        pip install ${aiida_core}
+                  pip install ${aiida_core}
 
-    - name: Setup up environment for AiiDA
-      env:
-        AIIDA_TEST_BACKEND: psql_dos
-      run: .github/aiida/setup_aiida.sh
+            - name: Setup up environment for AiiDA
+              env:
+                  AIIDA_TEST_BACKEND: psql_dos
+              run: .github/aiida/setup_aiida.sh
 
-    - name: Build docker image
-      run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
+            - name: Build docker image
+              run: docker-compose -f profiles/docker-compose-mongo.yml build --build-arg CONFIG_FILE=".github/mongo/ci_config.json"
 
-    - name: Start the Docker image
-      env:
-        AIIDA_OPTIMADE_LOG_LEVEL: INFO
-        USE_MONGO: '--mongo'
-        MONGO_FILENAME: test_structures_mongo.json
-      run: |
-        export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
-        docker-compose -f profiles/docker-compose-mongo.yml up &
-        .github/utils/wait_for_it.sh localhost:3253 -t 360
-        # Longer sleep, because the initialization is needed
-        sleep 30
+            - name: Start the Docker image
+              env:
+                  AIIDA_OPTIMADE_LOG_LEVEL: INFO
+                  USE_MONGO: --mongo
+                  MONGO_FILENAME: test_structures_mongo.json
+              run: |
+                  export DOCKER_HOST_IP=$(ip route | grep docker0 | awk '{print $9}')
+                  docker-compose -f profiles/docker-compose-mongo.yml up &
+                  .github/utils/wait_for_it.sh localhost:3253 -t 360
+                  # Longer sleep, because the initialization is needed
+                  sleep 30
 
-    - name: Test server with OPTIMADE Validator
-      uses: Materials-Consortia/optimade-validator-action@v2
-      with:
-        port: 3253
-        all versioned paths: yes
-        validate unversioned path: yes
-        validator version: latest
+            - name: Test server with OPTIMADE Validator
+              uses: Materials-Consortia/optimade-validator-action@v2
+              with:
+                  port: 3253
+                  all versioned paths: yes
+                  validate unversioned path: yes
+                  validator version: latest
 
-  build-package:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    build-package:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
 
-    steps:
-      - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Check build and install source distribution
-        uses: CasperWA/check-sdist-action@v1
+            - name: Check build and install source distribution
+              uses: CasperWA/check-sdist-action@v1

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,13 +104,13 @@ jobs:
         OPTIMADE_DATABASE_BACKEND: mongodb
       run: pytest -v --cov=./aiida_optimade/ --cov-report=xml:mongo_cov.xml --durations=20
 
-    - name: Test with pytest (Data Curation)
-      env:
-        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
-        AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
-        AIIDA_PROFILE: test_${{ matrix.backend }}
-        PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
-      run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --cov-append --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
+    # - name: Test with pytest (Data Curation)
+    #   env:
+    #     AIIDA_TEST_BACKEND: ${{ matrix.backend }}
+    #     AIIDA_TEST_PROFILE: test_${{ matrix.backend }}
+    #     AIIDA_PROFILE: test_${{ matrix.backend }}
+    #     PYTEST_OPTIMADE_CONFIG_FILE: ./tests/static/test_data_curation_config.json
+    #   run: pytest -v --cov=./aiida_optimade/ --cov-report=xml --cov-append --durations=20 tests/server/routers/test_structures.py::test_structures_endpoint_data
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ You can configure the server with the `aiida_optimade/config.json` file or set c
 
 To learn more about this, see the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools) repository.
 
+### Using AiiDA group for data curated
+
+The [AiiDA group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curated data and server in bias. 
+By setting the `query_group` in `config.json` can only server the structure data from the group.
+Set the `query_group` parameter to `null` (default) to server all structure data from the database.
+
 ## Design choices
 
 **Q: Why create an individual `config.json` file instead of just mounting an existing `.aiida` directory and using that directly?**  

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ You can configure the server with the `aiida_optimade/config.json` file or set c
 
 To learn more about this, see the [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools) repository.
 
-### Using AiiDA group for data curated
+### Using AiiDA group for curated data
 
-The [AiiDA group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curated data and server in bias. 
-By setting the `query_group` in `config.json` can only server the structure data from the group.
-Set the `query_group` parameter to `null` (default) to server all structure data from the database.
+An [AiiDA Group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curate data and server only this curated data through the OPTIMADE server. 
+Setting the `query_group` option in `config.json` will ensure only the valid (`StructureData`, `CifData`) data nodes in the given AiiDA Group will be served.
+Set the `query_group` parameter to `null` (default) to serve all structure data from the database.
 
 ## Design choices
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To learn more about this, see the [`optimade-python-tools`](https://github.com/M
 
 ### Using AiiDA group for curated data
 
-An [AiiDA Group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curate data and server only this curated data through the OPTIMADE server.
+An [AiiDA Group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curate data and serve only this curated data through the OPTIMADE server.
 Setting the `query_group` option in `config.json` will ensure only the valid (`StructureData`, `CifData`) data nodes in the given AiiDA Group will be served.
 Set the `query_group` parameter to `null` (default) to serve all structure data from the database.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To learn more about this, see the [`optimade-python-tools`](https://github.com/M
 
 ### Using AiiDA group for curated data
 
-An [AiiDA Group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curate data and server only this curated data through the OPTIMADE server. 
+An [AiiDA Group](https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/data.html#organizing-data) can be used to curate data and server only this curated data through the OPTIMADE server.
 Setting the `query_group` option in `config.json` will ensure only the valid (`StructureData`, `CifData`) data nodes in the given AiiDA Group will be served.
 Set the `query_group` parameter to `null` (default) to serve all structure data from the database.
 

--- a/aiida_optimade/config.py
+++ b/aiida_optimade/config.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from pydantic import Field
+
+from optimade.server.config import ServerConfig
+
+
+class CustomServerConfig(ServerConfig):
+
+    query_group: Optional[str] = Field(
+        None, description="The aiida group where curate the data for query."
+    )
+
+
+CONFIG: ServerConfig = CustomServerConfig()

--- a/aiida_optimade/config.py
+++ b/aiida_optimade/config.py
@@ -8,7 +8,8 @@ from optimade.server.config import ServerConfig
 class CustomServerConfig(ServerConfig):
 
     query_group: Optional[str] = Field(
-        None, description="The aiida group where curate the data for query."
+        None,
+        description="The AiiDA Group containing the data that will be served, allowing one to serve a curated set of data from a given database.",
     )
 
 

--- a/aiida_optimade/config.py
+++ b/aiida_optimade/config.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
-from pydantic import Field
-
 from optimade.server.config import ServerConfig
+from pydantic import Field
 
 
 class CustomServerConfig(ServerConfig):

--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -1,11 +1,9 @@
-from typing import Any, Dict, Tuple, List, Set, Union, Optional
 import warnings
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
+from aiida.orm import Group
 from aiida.orm.nodes import Node
 from aiida.orm.querybuilder import QueryBuilder
-from aiida.orm import Group
-
 from optimade.models import EntryResource
 from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest, NotFound

--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -1,8 +1,11 @@
+from typing import Any, Dict, Tuple, List, Set, Union, Optional
 import warnings
 from typing import Any, Dict, List, Set, Tuple, Union
 
 from aiida.orm.nodes import Node
 from aiida.orm.querybuilder import QueryBuilder
+from aiida.orm import Group
+
 from optimade.models import EntryResource
 from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest, NotFound
@@ -31,6 +34,7 @@ class AiidaCollection(EntryCollection):
     def __init__(
         self,
         entities: Union[str, List[str]],
+        group: Optional[str],
         resource_cls: EntryResource,
         resource_mapper: ResourceMapper,
     ):
@@ -41,6 +45,7 @@ class AiidaCollection(EntryCollection):
         )
 
         self.entities = entities if isinstance(entities, list) else [entities]
+        self.group = group
 
         # "Cache"
         self._data_available: int = None
@@ -292,7 +297,9 @@ class AiidaCollection(EntryCollection):
         return results, more_data_available
 
     @staticmethod
-    def _prepare_query(node_types: List[str], **kwargs) -> QueryBuilder:
+    def _prepare_query(
+        node_types: List[str], group: Optional[str] = None, **kwargs
+    ) -> QueryBuilder:
         """Workhorse function to prepare an AiiDA QueryBuilder query"""
         for key in kwargs:
             if key not in {"filters", "order_by", "limit", "project", "offset"}:
@@ -310,7 +317,11 @@ class AiidaCollection(EntryCollection):
         project = kwargs.get("project", [])
 
         query = QueryBuilder(limit=limit, offset=offset)
-        query.append(Node, project=project, filters=filters)
+        if group:
+            query.append(Group, filters={"label": group}, tag="group")
+            query.append(Node, with_group="group", project=project, filters=filters)
+        else:
+            query.append(Node, project=project, filters=filters)
         query.order_by(order_by)
 
         return query
@@ -320,7 +331,7 @@ class AiidaCollection(EntryCollection):
         LOGGER.debug(
             "Using QueryBuilder to get ALL projected values from found entries."
         )
-        query = self._prepare_query(self.entities, **kwargs)
+        query = self._prepare_query(self.entities, self.group, **kwargs)
         res = query.all()
         del query
         return res
@@ -328,7 +339,7 @@ class AiidaCollection(EntryCollection):
     def _perform_count(self, **kwargs) -> int:
         """Instantiate new QueryBuilder object and perform count()"""
         LOGGER.debug("Using QueryBuilder to COUNT all found entries.")
-        query = self._prepare_query(self.entities, **kwargs)
+        query = self._prepare_query(self.entities, self.group, **kwargs)
         res = query.count()
         del query
         return res

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -2,7 +2,12 @@
 from typing import Union
 
 from fastapi import APIRouter, Depends, Request
-from optimade.models import ErrorResponse, StructureResponseMany, StructureResponseOne
+
+from optimade.models import (
+    ErrorResponse,
+    StructureResponseMany,
+    StructureResponseOne,
+)
 from optimade.server.config import CONFIG, SupportedBackend
 from optimade.server.entry_collections.mongo import MongoCollection
 from optimade.server.mappers.structures import (
@@ -13,11 +18,13 @@ from optimade.server.query_params import EntryListingQueryParams, SingleEntryQue
 from aiida_optimade.entry_collections import AiidaCollection
 from aiida_optimade.mappers import StructureMapper
 from aiida_optimade.models import StructureResource
-from aiida_optimade.routers.utils import close_session, get_entries, get_single_entry
+from aiida_optimade.routers.utils import get_entries, get_single_entry, close_session
+from aiida_optimade.config import CONFIG
 
 ROUTER = APIRouter(redirect_slashes=True)
 
 STRUCTURES = AiidaCollection(
+    group=CONFIG.query_group,
     entities=["data.core.cif.CifData.", "data.core.structure.StructureData."],
     resource_cls=StructureResource,
     resource_mapper=StructureMapper,

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -15,11 +15,11 @@ from optimade.server.mappers.structures import (
 )
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
+from aiida_optimade.config import CONFIG
 from aiida_optimade.entry_collections import AiidaCollection
 from aiida_optimade.mappers import StructureMapper
 from aiida_optimade.models import StructureResource
 from aiida_optimade.routers.utils import get_entries, get_single_entry, close_session
-from aiida_optimade.config import CONFIG
 
 ROUTER = APIRouter(redirect_slashes=True)
 

--- a/aiida_optimade/routers/structures.py
+++ b/aiida_optimade/routers/structures.py
@@ -2,13 +2,8 @@
 from typing import Union
 
 from fastapi import APIRouter, Depends, Request
-
-from optimade.models import (
-    ErrorResponse,
-    StructureResponseMany,
-    StructureResponseOne,
-)
-from optimade.server.config import CONFIG, SupportedBackend
+from optimade.models import ErrorResponse, StructureResponseMany, StructureResponseOne
+from optimade.server.config import SupportedBackend
 from optimade.server.entry_collections.mongo import MongoCollection
 from optimade.server.mappers.structures import (
     StructureMapper as OptimadeStructureMapper,
@@ -19,7 +14,7 @@ from aiida_optimade.config import CONFIG
 from aiida_optimade.entry_collections import AiidaCollection
 from aiida_optimade.mappers import StructureMapper
 from aiida_optimade.models import StructureResource
-from aiida_optimade.routers.utils import get_entries, get_single_entry, close_session
+from aiida_optimade.routers.utils import close_session, get_entries, get_single_entry
 
 ROUTER = APIRouter(redirect_slashes=True)
 

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from optimade.models import (
     ReferenceResource,
@@ -8,6 +9,11 @@ from optimade.models import (
 from ..utils import EndpointTests
 
 
+@pytest.mark.skipif(
+    os.getenv("PYTEST_OPTIMADE_CONFIG_FILE")
+    != "./tests/static/test_data_curation_config.json",
+    reason="Test is not for data curation",
+)
 def test_structures_endpoint_data(get_good_response):
     """Check known properties/attributes for successful response"""
     from optimade.server.config import CONFIG
@@ -17,7 +23,7 @@ def test_structures_endpoint_data(get_good_response):
     assert "data" in response
     assert len(response["data"]) == CONFIG.page_limit
     assert "meta" in response
-    assert response["meta"]["data_available"] == 1620
+    assert response["meta"]["data_available"] == 528
     assert response["meta"]["more_data_available"]
 
 

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from optimade.models import (
     ReferenceResource,

--- a/tests/static/test_data_curation_config.json
+++ b/tests/static/test_data_curation_config.json
@@ -1,6 +1,6 @@
 {
   "debug": true,
-  "query_group": null,
+  "query_group": "all_cifdata",
   "page_limit": 15,
   "page_limit_max": 500,
   "default_db": "aiida_optimade",
@@ -14,7 +14,7 @@
   },
   "implementation": {
     "name": "aiida-optimade",
-    "version": "1.0.1",
+    "version": "0.19.0",
     "source_url": "https://github.com/aiidateam/aiida-optimade",
     "maintainer": {"email": "casper.andersen@epfl.ch"}
   },

--- a/tests/static/test_mongo_config.json
+++ b/tests/static/test_mongo_config.json
@@ -1,5 +1,6 @@
 {
     "debug": true,
+    "query_group": null,
     "page_limit": 15,
     "page_limit_max": 500,
     "default_db": "aiida_optimade",

--- a/tests/static/test_mongo_config.json
+++ b/tests/static/test_mongo_config.json
@@ -1,6 +1,5 @@
 {
     "debug": true,
-    "query_group": null,
     "page_limit": 15,
     "page_limit_max": 500,
     "default_db": "aiida_optimade",


### PR DESCRIPTION
Fix #237

By setting `query_group` in config will ask optimade to only query the node in the corresponding group. 
The setting will also influence the Mongo database creation.

- [x] New archive with group to test this new feature, where I append 5 more structure data. If the `query_group` is not set in the config one of the test failed `FAILED tests/server/routers/test_structures.py::TestStructuresEndpoint::test_structures_endpoint_data - assert 1625 == 1620`