### PR TITLE
Fix/openapi endpoints

### DIFF
--- a/aiida_optimade/config.json
+++ b/aiida_optimade/config.json
@@ -27,7 +27,7 @@
       "type": "node_type",
       "relationships": "attributes.something.non.existing",
       "links": "attributes.something.non.existing",
-      "meta": "attributes.someting.non.existing"
+      "meta": "attributes.something.non.existing"
     }
   }
 }

--- a/aiida_optimade/config.json
+++ b/aiida_optimade/config.json
@@ -2,6 +2,7 @@
   "page_limit": 15,
   "page_limit_max": 500,
   "base_url": null,
+  "root_path": null,
   "provider": {
     "prefix": "aiida",
     "name": "AiiDA",

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -64,6 +64,7 @@ if CONFIG.debug:
     LOGGER.info("DEBUG MODE")
 
 APP = FastAPI(
+    root_path=CONFIG.root_path,
     title="OPTIMADE API for AiiDA",
     description=(
         "The [Open Databases Integration for Materials Design (OPTIMADE) consortium]"

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -42,7 +42,7 @@ from aiida_optimade.routers import (
     links,
     structures,
 )
-from aiida_optimade.utils import get_custom_base_url_path, OPEN_API_ENDPOINTS
+from aiida_optimade.utils import OPEN_API_ENDPOINTS
 
 
 if not Path(os.getenv("OPTIMADE_CONFIG_FILE", DEFAULT_CONFIG_FILE_PATH)).exists():
@@ -63,7 +63,6 @@ else:
 if CONFIG.debug:
     LOGGER.info("DEBUG MODE")
 
-DOCS_ENDPOINT_PREFIX = f"{get_custom_base_url_path()}{BASE_URL_PREFIXES['major']}"
 APP = FastAPI(
     title="OPTIMADE API for AiiDA",
     description=(
@@ -75,9 +74,9 @@ APP = FastAPI(
         "reproducible."
     ),
     version=__api_version__,
-    docs_url=f"{DOCS_ENDPOINT_PREFIX}{OPEN_API_ENDPOINTS['docs']}",
-    redoc_url=f"{DOCS_ENDPOINT_PREFIX}{OPEN_API_ENDPOINTS['redoc']}",
-    openapi_url=f"{DOCS_ENDPOINT_PREFIX}{OPEN_API_ENDPOINTS['openapi']}",
+    docs_url=f"{BASE_URL_PREFIXES['major']}{OPEN_API_ENDPOINTS['docs']}",
+    redoc_url=f"{BASE_URL_PREFIXES['major']}{OPEN_API_ENDPOINTS['redoc']}",
+    openapi_url=f"{BASE_URL_PREFIXES['major']}{OPEN_API_ENDPOINTS['openapi']}",
 )
 
 

--- a/aiida_optimade/main.py
+++ b/aiida_optimade/main.py
@@ -64,6 +64,7 @@ if CONFIG.debug:
     LOGGER.info("DEBUG MODE")
 
 APP = FastAPI(
+    base_url=CONFIG.base_url,
     root_path=CONFIG.root_path,
     title="OPTIMADE API for AiiDA",
     description=(

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -1,8 +1,6 @@
 from typing import Tuple
-import urllib.parse
 
 from optimade.models import DataType
-from optimade.server.config import CONFIG
 
 
 OPEN_API_ENDPOINTS = {

--- a/aiida_optimade/utils.py
+++ b/aiida_optimade/utils.py
@@ -52,16 +52,3 @@ def retrieve_queryable_properties(
                 )
 
     return properties, all_properties
-
-
-def get_custom_base_url_path():
-    """Return path part of custom base URL"""
-    if CONFIG.base_url is not None:
-        res = urllib.parse.urlparse(CONFIG.base_url).path
-    else:
-        res = urllib.parse.urlparse(CONFIG.base_url).path.decode()
-
-    while res.endswith("/"):
-        res = res[:-1]
-
-    return res


### PR DESCRIPTION
Currently the endpoints 

```
"extensions/docs",
"extensions/redoc",
"extensions/openapi.json",
```

are not available on materialscloud. See e.g. https://aiida.materialscloud.org/optimade-sample/optimade/v1/extensions/docs

(but they are listed on https://aiida.materialscloud.org/optimade-sample/optimade/v1/info)

On localhost, they are available.

The problem seems to stem from here:

https://github.com/aiidateam/aiida-optimade/blob/b48cb39e27ddf1db3e65322412bdd1ecf5b0ee67/aiida_optimade/main.py#L78-L80

Comparing with similar code in optimade-python-tools

https://github.com/Materials-Consortia/optimade-python-tools/blob/281ca780881d9529d7d247e5075eddf08152a362/optimade/server/main.py#L57-L59

they don't add the full path to the corresponding arguments.

I changed the code to be similar as optimade-python-tools and now everything seems to work. I removed the `get_custom_base_url_path()` function for maintainability, as it remains unused now.