### PR TITLE
fix `skip: 0` case

### DIFF
--- a/aiida_optimade/entry_collections.py
+++ b/aiida_optimade/entry_collections.py
@@ -373,7 +373,7 @@ class AiidaCollection(EntryCollection):
             cursor_kwargs["order_by"] = cursor_kwargs.pop("sort")
 
         # page_offset
-        if cursor_kwargs.get("skip", False):
+        if "skip" in cursor_kwargs:
             cursor_kwargs["offset"] = cursor_kwargs.pop("skip")
 
         return cursor_kwargs


### PR DESCRIPTION
When accessing structures and specifying `?page_number=1`

The error occurs:

```
ValueError: You supplied key 'skip'. The only valid query keys are: "filters", "order_by", "limit", "project", "offset"
```

This is because `cursor_kwargs` will contain `"skip": 0`, which will evaluate to False and therefore the key is kept in the dictionary, causing the error. Not fully sure why this didn't come up before.

This PR makes it that in any case, the `skip` key is handled and removed.

Thanks to @unkcpz and Johan Bergma in optimade slack for the comment.