### PR TITLE
Migrating to aiida v2.5 and optimade-python-tools 1.0

### DIFF
--- a/aiida_optimade/mappers/entries.py
+++ b/aiida_optimade/mappers/entries.py
@@ -21,6 +21,12 @@ class ResourceMapper(OptimadeResourceMapper):
         "relationships",
         "links",
         "meta",
+        "description",
+        "related",
+        "structures",
+        "data",
+        "self",
+        "references",
     }
 
     @classmethod

--- a/aiida_optimade/mappers/structures.py
+++ b/aiida_optimade/mappers/structures.py
@@ -22,7 +22,9 @@ class StructureMapper(ResourceMapper):
         "data.core.cif.CifData.": CifDataTranslator,
         "data.core.structure.StructureData.": StructureDataTranslator,
     }
-    REQUIRED_ATTRIBUTES = set(StructureResourceAttributes.schema().get("required"))
+    REQUIRED_ATTRIBUTES = set(
+        StructureResourceAttributes.model_json_schema().get("required")
+    )
     # This should be REQUIRED_FIELDS, but should be set as such in `optimade`
     ENTRY_RESOURCE_CLASS = StructureResource
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-optimade[server]~=0.25.3
-aiida-core~=2.4.0
-pymatgen>=2019.7.2,!=2019.9.7,<2023.11.13
+optimade[server]~=1.0.1
+aiida-core~=2.5.0
+#pymatgen>=2019.7.2,!=2019.9.7,<2023.11.13
 
 # Dependencies used directly in this package, but included through other dependencies:
 # aiida-core:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -10,7 +10,7 @@ import pytest
 
 
 @pytest.fixture
-def aiida_test_profile() -> str:
+def aiida_test_profile_name() -> str:
     """Return AiiDA test profile used for AiiDA-OPTIMADE"""
     from aiida_optimade.cli.cmd_aiida_optimade import AIIDA_OPTIMADE_TEST_PROFILE
 
@@ -18,7 +18,7 @@ def aiida_test_profile() -> str:
 
 
 @pytest.fixture
-def run_cli_command(aiida_test_profile: str):
+def run_cli_command(aiida_test_profile_name: str):
     """Run a `click` command with the given options.
 
     The call will raise if the command triggered an exception or the exit code returned
@@ -42,10 +42,10 @@ def run_cli_command(aiida_test_profile: str):
         import traceback
 
         runner = click.testing.CliRunner()
-        profile = os.getenv("AIIDA_PROFILE", aiida_test_profile)
+        profile = os.getenv("AIIDA_PROFILE", aiida_test_profile_name)
         if profile == "test_profile":
             # This is for local tests only
-            profile = aiida_test_profile
+            profile = aiida_test_profile_name
         result = runner.invoke(command, options or [], env={"AIIDA_PROFILE": profile})
 
         if raises:
@@ -67,7 +67,7 @@ def run_cli_command(aiida_test_profile: str):
 
 
 @pytest.fixture
-def run_and_terminate_server(aiida_test_profile: str):
+def run_and_terminate_server(aiida_test_profile_name: str):
     """Run a `click` command with the given options.
 
     The call will raise if the command triggered an exception or the exit code returned
@@ -88,10 +88,10 @@ def run_and_terminate_server(aiida_test_profile: str):
         :param raises: Whether the command is expected to raise an exception
         :return: Test result
         """
-        profile = os.getenv("AIIDA_PROFILE", aiida_test_profile)
+        profile = os.getenv("AIIDA_PROFILE", aiida_test_profile_name)
         if profile == "test_profile":
             # This is for local tests only
-            profile = aiida_test_profile
+            profile = aiida_test_profile_name
 
         args = ["aiida-optimade", "-p", profile]
         args.append(command)

--- a/tests/cli/test_calc.py
+++ b/tests/cli/test_calc.py
@@ -10,7 +10,7 @@ import pytest
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is not None,
     reason="Test is not for MongoDB",
 )
-def test_calc_all_new(run_cli_command, aiida_profile, top_dir, caplog):
+def test_calc_all_new(run_cli_command, aiida_profile_populated, top_dir, caplog):
     """Test `aiida-optimade -p profile_name calc` works for non-existent fields.
 
     By "non-existent" the meaning is calculating fields that don't already exist for
@@ -23,7 +23,7 @@ def test_calc_all_new(run_cli_command, aiida_profile, top_dir, caplog):
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear database and get initialized_structure_nodes.aiida
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     archive = top_dir.joinpath("tests/cli/static/initialized_structure_nodes.aiida")
     import_archive(archive)
 
@@ -96,7 +96,7 @@ def test_calc_all_new(run_cli_command, aiida_profile, top_dir, caplog):
     ), caplog.text
 
     # Repopulate database with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     original_data = top_dir.joinpath("tests/static/test_structures.aiida")
     import_archive(original_data)
 
@@ -105,7 +105,7 @@ def test_calc_all_new(run_cli_command, aiida_profile, top_dir, caplog):
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is not None,
     reason="Test is not for MongoDB",
 )
-def test_calc(run_cli_command, aiida_profile, top_dir):
+def test_calc(run_cli_command, aiida_profile_populated, top_dir):
     """Test `aiida-optimade -p profile_name calc` works."""
     from aiida import orm
     from aiida.tools.archive.imports import import_archive
@@ -114,7 +114,7 @@ def test_calc(run_cli_command, aiida_profile, top_dir):
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear database and get initialized_structure_nodes.aiida
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     archive = top_dir.joinpath("tests/cli/static/initialized_structure_nodes.aiida")
     import_archive(archive)
 
@@ -158,7 +158,7 @@ def test_calc(run_cli_command, aiida_profile, top_dir):
     assert n_structure_data == n_updated_structure_data
 
     # Repopulate database with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     original_data = top_dir.joinpath("tests/static/test_structures.aiida")
     import_archive(original_data)
 
@@ -167,7 +167,7 @@ def test_calc(run_cli_command, aiida_profile, top_dir):
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is not None,
     reason="Test is not for MongoDB",
 )
-def test_calc_partially_init(run_cli_command, aiida_profile, top_dir, caplog):
+def test_calc_partially_init(run_cli_command, aiida_profile_populated, top_dir, caplog):
     """Test `aiida-optimade -p profile_name calc` works for a partially initalized DB"""
     from aiida import orm
     from aiida.tools.archive.imports import import_archive
@@ -176,7 +176,7 @@ def test_calc_partially_init(run_cli_command, aiida_profile, top_dir, caplog):
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear database and get initialized_structure_nodes.aiida
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     archive = top_dir.joinpath("tests/cli/static/initialized_structure_nodes.aiida")
     import_archive(archive)
 
@@ -255,6 +255,6 @@ def test_calc_partially_init(run_cli_command, aiida_profile, top_dir, caplog):
     ), caplog.text
 
     # Repopulate database with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     original_data = top_dir.joinpath("tests/static/test_structures.aiida")
     import_archive(original_data)

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -10,7 +10,7 @@ import pytest
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is not None,
     reason="Test is not for MongoDB",
 )
-def test_init_structuredata(run_cli_command, aiida_profile, top_dir, caplog):
+def test_init_structuredata(run_cli_command, aiida_profile_populated, top_dir, caplog):
     """Test `aiida-optimade -p profile_name init` works for StructureData Nodes.
 
     Also, check the `-f/--force` option.
@@ -22,7 +22,7 @@ def test_init_structuredata(run_cli_command, aiida_profile, top_dir, caplog):
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear database
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
 
     archive = top_dir.joinpath("tests/cli/static/structure_data_nodes.aiida")
     import_archive(archive)
@@ -82,7 +82,7 @@ def test_init_structuredata(run_cli_command, aiida_profile, top_dir, caplog):
     ), caplog.text
 
     # Repopulate database with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     original_data = top_dir.joinpath("tests/static/test_structures.aiida")
     import_archive(original_data)
 
@@ -91,7 +91,7 @@ def test_init_structuredata(run_cli_command, aiida_profile, top_dir, caplog):
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is not None,
     reason="Test is not for MongoDB",
 )
-def test_init_cifdata(run_cli_command, aiida_profile, top_dir, caplog):
+def test_init_cifdata(run_cli_command, aiida_profile_populated, top_dir, caplog):
     """Test `aiida-optimade -p profile_name init` works for CifData Nodes."""
     from aiida import orm
     from aiida.tools.archive.imports import import_archive
@@ -100,7 +100,7 @@ def test_init_cifdata(run_cli_command, aiida_profile, top_dir, caplog):
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear database
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
 
     archive = top_dir.joinpath("tests/cli/static/cif_data_nodes.aiida")
     import_archive(archive)
@@ -136,7 +136,7 @@ def test_init_cifdata(run_cli_command, aiida_profile, top_dir, caplog):
     ), caplog.text
 
     # Repopulate database with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     original_data = top_dir.joinpath("tests/static/test_structures.aiida")
     import_archive(original_data)
 
@@ -144,7 +144,9 @@ def test_init_cifdata(run_cli_command, aiida_profile, top_dir, caplog):
 @pytest.mark.skipif(
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is None, reason="Test is only for MongoDB"
 )
-def test_init_structuredata_mongo(run_cli_command, aiida_profile, top_dir, caplog):
+def test_init_structuredata_mongo(
+    run_cli_command, aiida_profile_populated, top_dir, caplog
+):
     """Test `aiida-optimade -p profile_name init --mongo` works for StructureData Nodes.
 
     Also, check the `-f/--force` option.
@@ -158,7 +160,7 @@ def test_init_structuredata_mongo(run_cli_command, aiida_profile, top_dir, caplo
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear databases
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     STRUCTURES_MONGO.collection.drop()
 
     archive = top_dir.joinpath("tests/cli/static/structure_data_nodes.aiida")
@@ -222,7 +224,7 @@ def test_init_structuredata_mongo(run_cli_command, aiida_profile, top_dir, caplo
     ), caplog.text
 
     # Repopulate databases with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     import_archive(top_dir.joinpath("tests/static/test_structures.aiida"))
     STRUCTURES_MONGO.collection.drop()
     with open(top_dir.joinpath("tests/static/test_structures_mongo.json")) as handle:
@@ -233,7 +235,7 @@ def test_init_structuredata_mongo(run_cli_command, aiida_profile, top_dir, caplo
 @pytest.mark.skipif(
     os.getenv("PYTEST_OPTIMADE_CONFIG_FILE") is None, reason="Test is only for MongoDB"
 )
-def test_init_cifdata_mongo(run_cli_command, aiida_profile, top_dir, caplog):
+def test_init_cifdata_mongo(run_cli_command, aiida_profile_populated, top_dir, caplog):
     """Test `aiida-optimade -p profile_name init` works for CifData Nodes."""
     import bson.json_util
     from aiida import orm
@@ -244,7 +246,7 @@ def test_init_cifdata_mongo(run_cli_command, aiida_profile, top_dir, caplog):
     from aiida_optimade.translators.entities import AiidaEntityTranslator
 
     # Clear databases
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     STRUCTURES_MONGO.collection.drop()
 
     archive = top_dir.joinpath("tests/cli/static/cif_data_nodes.aiida")
@@ -283,7 +285,7 @@ def test_init_cifdata_mongo(run_cli_command, aiida_profile, top_dir, caplog):
     ), caplog.text
 
     # Repopulate database with the "proper" test data
-    aiida_profile.reset_db()
+    aiida_profile_populated.clear_profile()
     import_archive(top_dir.joinpath("tests/static/test_structures.aiida"))
     STRUCTURES_MONGO.collection.drop()
     with open(top_dir.joinpath("tests/static/test_structures_mongo.json")) as handle:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -10,17 +10,17 @@ import requests
 
 
 @pytest.fixture
-def run_server(aiida_test_profile: str):
+def run_server(aiida_test_profile_name: str):
     """Run the server using `aiida-optimade run`
 
     :param options: the list of command line options to pass to `aiida-optimade run`
         invocation
     :param raises: whether `aiida-optimade run` is expected to raise an exception
     """
-    profile = os.getenv("AIIDA_PROFILE", aiida_test_profile)
+    profile = os.getenv("AIIDA_PROFILE", aiida_test_profile_name)
     if profile == "test_profile":
         # This is for local tests only
-        profile = aiida_test_profile
+        profile = aiida_test_profile_name
 
     args = ["aiida-optimade", "-p", profile, "run"]
     env = dict(os.environ)
@@ -115,7 +115,7 @@ def test_logging_precedence(run_and_terminate_server):
     ), f"output: {output!r}, errors: {errors!r}"
 
 
-def test_env_var_is_set(run_and_terminate_server, aiida_test_profile: str):
+def test_env_var_is_set(run_and_terminate_server, aiida_test_profile_name: str):
     """Test the AIIDA_PROFILE env var is set
 
     The issue with this test, is that the set "AIIDA_PROFILE" environment variable
@@ -131,7 +131,7 @@ def test_env_var_is_set(run_and_terminate_server, aiida_test_profile: str):
     assert fixture_profile is not None
     if fixture_profile == "test_profile":
         # This is for local tests only
-        fixture_profile = aiida_test_profile
+        fixture_profile = aiida_test_profile_name
     output, errors = run_and_terminate_server(command="run")
     assert fixture_profile in output, f"output: {output!r}, errors: {errors!r}"
 


### PR DESCRIPTION
Hi @CasperWA, I would really need some fixes that are in aiida v2.5.0 (namely, mutating nodes with iterall()) to enable the optimade api for some large DBs on materials cloud (would be great to have before submisison of the optimade paper).

However, aiida v2.5.0 migrated to pydantic 2 and therefore it looks like the optimade-python-tools dependency should also be upgraded to 1.0.

Additionally, aiida v2.5 removed the ["legacy testing"](https://github.com/aiidateam/aiida-core/pull/6163) that was used in this repo. This i managed migrate to the new format.

However, i am not able to adapt this repo to optimade-python-tools 1.0. No specific error is raised, but just the functionality is not correct (e.g. it re-calculates the optimade extras every time; there seem to be spurious optimade attributes in random places, etc). 

Would be great if you could take a look! Feel free to contribute directly to this PR.